### PR TITLE
Use `pip install .` instead of requirements.txt for travis-ci.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,5 @@ language: python
 python:
   - "2.6"
   - "2.7"
-install: "pip install -r requirements.txt --use-mirrors"
+install: "pip install -e . --use-mirrors"
 script: "py.test"


### PR DESCRIPTION
Hopefully this catches most issues with `pip install` being broken.
