### PR TITLE
Fix readme TOC links when viewed on github

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -172,8 +172,8 @@ Python module usage
 Below is brief overview of the ``internetarchive`` Python library.
 Please refer to the `API documentation <http://ia-wrapper.readthedocs.org/en/latest/>`__ for more specific details.
 
-Downloading
-~~~~~~~~~~~
+Downloading from Python
+~~~~~~~~~~~~~~~~~~~~~~~
 
 The Internet Archive stores data in
 `items <http://blog.archive.org/2011/03/31/how-archive-org-items-are-structured/>`__.
@@ -206,8 +206,8 @@ You can iterate over files:
     >>> for f in item.files():
     ...     print f.name, f.sha1
 
-Uploading
-~~~~~~~~~
+Uploading from Python
+~~~~~~~~~~~~~~~~~~~~~
 
 You can use the IA's S3-like interface to upload files to an item. You
 need to supply your IAS3 credentials in environment variables in order
@@ -242,8 +242,8 @@ You can also upload file-like objects:
     >>> item.upload(fh)
 
 
-Modifying Metadata
-~~~~~~~~~~~~~~~~~~
+Modifying Metadata from Python
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 You can modify metadata for existing items, using the
 ``item.modify_metadata()`` function. This uses the `IA Metadata
@@ -260,8 +260,8 @@ and requires your IAS3 credentials.
     >>> item.modify_metadata(md)
 
 
-Searching
-~~~~~~~~~
+Searching from Python
+~~~~~~~~~~~~~~~~~~~~~
 
 You can search for items using the `archive.org advanced search
 engine <https://archive.org/advancedsearch.php>`__:


### PR DESCRIPTION
Minor change to README.rst to give each subsection a unique heading.

This is necessary because Github has an issue with Table of Contents links that are not unique (although pypi is fine with them).
