### PR TITLE
do not use mutable defaults

### DIFF
--- a/internetarchive/item.py
+++ b/internetarchive/item.py
@@ -330,7 +330,7 @@ class Item(object):
 
     # upload_file()
     # ____________________________________________________________________________________
-    def upload_file(self, body, key=None, metadata={}, headers={},
+    def upload_file(self, body, key=None, metadata=None, headers=None,
                     access_key=None, secret_key=None, queue_derive=True,
                     ignore_preexisting_bucket=False, verbose=False, verify=True,
                     checksum=False, delete=False, retries=0, retries_sleep=20, 
@@ -393,6 +393,13 @@ class Item(object):
             True
 
         """
+
+        if headers is None:
+            headers = {}
+
+        if metadata is None:
+            metadata = {}
+
         access_key = self.session.access_key if not access_key else access_key
         secret_key = self.session.secret_key if not secret_key else secret_key
 

--- a/tests/upload.py
+++ b/tests/upload.py
@@ -54,14 +54,14 @@ def get_file(item_name, file_name):
 
 # upload_stringIO()
 #_________________________________________________________________________________________
-def upload_stringIO(item):
+def upload_stringIO(item, metadata=dict(collection='test_collection')):
     contents = 'hello world'
     name = 'hello_world.txt'
 
     fh = StringIO.StringIO(contents)
     fh.name = name
 
-    r = item.upload(fh, metadata=dict(collection='test_collection'), access_key=access,
+    r = item.upload(fh, metadata=metadata, access_key=access,
                     secret_key=secret)
 
     f = get_file(item.identifier, name)
@@ -85,6 +85,25 @@ def upload_tempfile(item):
     assert f.sha1 == hashlib.sha1(contents).hexdigest()
 
 
+# upload_two_new_tems()
+#_________________________________________________________________________________________
+def upload_two_new_items():
+    first_item = get_new_item()
+    second_item = get_new_item()
+
+    upload_stringIO(first_item, metadata={
+            'collection': 'test_collection',
+            'description': 'testing ia-wrapper {}'.format(first_item.identifier),
+        })
+    upload_stringIO(second_item, metadata={
+            'collection': 'test_collection',
+            'description': '',
+        })
+    first_item.get_metadata()
+    second_item.get_metadata()
+    assert first_item.metadata['description'] != second_item.metadata['description']
+
+
 # test_upload()
 #_________________________________________________________________________________________
 def test_upload():
@@ -98,6 +117,9 @@ def test_upload():
 
     print 'Testing upload using tempfile'
     upload_tempfile(item)
+
+    print 'Testing that subsequent uploads do not have headers from previous uploads'
+    upload_two_new_items()
 
     print 'Finished upload test'
 


### PR DESCRIPTION
The upload_file in item.py was using mutable defaults for metadata and headers. As explained by netbat, using [multable defaults](http://stackoverflow.com/questions/25351440/why-are-stale-header-values-still-around-when-uploading-a-subsequent-item-to-arc) causes the problem reported in #64.

The way I tested this was to run the code in my stackoverflow question against master and against this branch. Stale headers are used in master, they are not used in in this branch. 

I did add an extra test to upload.py to check this, but upload.py seems to fail intermittently. Are you using it? I can update my PR to leave the change out.
