### PR TITLE
Added ceil to total_pages

### DIFF
--- a/internetarchive/search.py
+++ b/internetarchive/search.py
@@ -1,7 +1,7 @@
 import requests.sessions
 
 from . import session
-
+from math import ceil
 
 # Search class
 # ________________________________________________________________________________________
@@ -60,7 +60,7 @@ class Search(object):
     # ____________________________________________________________________________________
     def __iter__(self):
         """Generator for iterating over search results"""
-        total_pages = ((self.num_found / self.params['rows']) + 2)
+        total_pages = ceil(((self.num_found / self.params['rows'])) + 2)
         for page in range(1, total_pages):
             self.params['page'] = page
             r = self.http_session.get(self.url, params=self.params)


### PR DESCRIPTION
Added ceil function to total_pages calculation. This remedies the implicit conversion from float to int on the total_pages. This eliminates an exception as well as (I believe) the potential for missing the last set of items returned by the Internet Archive when the last page of results is less than 100 items.
