### PR TITLE
quote header values that contain non-asci encodings or whitespace

### DIFF
--- a/internetarchive/iarequest.py
+++ b/internetarchive/iarequest.py
@@ -12,6 +12,7 @@ import requests
 from jsonpatch import make_patch
 
 from . import auth
+from internetarchive.utils import needs_quote
 
 
 class S3Request(requests.models.Request):
@@ -112,7 +113,7 @@ class S3PreparedRequest(requests.models.PreparedRequest):
                 if not value:
                     continue
                 header_key = 'x-archive-meta{0:02d}-{1}'.format(i, meta_key)
-                if any(c in str(value) for c in ['\n', '\r']):
+                if needs_quote(value):
                     value = 'uri({0})'.format(urllib.parse.quote(value))
                 # because rfc822 http headers disallow _ in names, IA-S3 will
                 # translate two hyphens in a row (--) into an underscore (_).

--- a/internetarchive/utils.py
+++ b/internetarchive/utils.py
@@ -1,5 +1,14 @@
 import hashlib
 import os
+import re
+
+
+def needs_quote(s):
+    try:
+        s.decode('ascii')
+    except UnicodeDecodeError:
+        return True
+    return re.search(r'\s', s) is not None
 
 
 def get_md5(file_object):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,6 @@
-import os, sys, shutil
+# -*- coding: utf-8 -*-
+
+import os, sys, shutil, string
 inc_path = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, inc_path)
 
@@ -9,3 +11,11 @@ def test_utils():
     ifp = internetarchive.utils.IterableToFileAdapter([1, 2], 200)
     assert len(ifp) == 200
     ifp.read()
+
+
+def test_needs_quote():
+    notascii = 'ȧƈƈḗƞŧḗḓ ŧḗẋŧ ƒǿř ŧḗşŧīƞɠ, ℛℯα∂α♭ℓℯ ♭ʊ☂ η☺т Ѧ$☾ℐℐ, ¡ooʇ ןnɟǝsn sı uʍop-ǝpısdn'
+    assert internetarchive.utils.needs_quote(notascii)
+    assert internetarchive.utils.needs_quote(string.whitespace)
+    assert not internetarchive.utils.needs_quote(string.ascii_letters + string.digits)
+

--- a/tests/upload.py
+++ b/tests/upload.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# -*- coding: utf-8 -*-
 
 """Test uploading through the internetarchive python package.
 
@@ -11,6 +12,7 @@ import datetime
 import hashlib
 import os
 import StringIO
+import string
 import tempfile
 import time
 
@@ -57,7 +59,6 @@ def get_file(item_name, file_name):
 def upload_stringIO(item, metadata=dict(collection='test_collection')):
     contents = 'hello world'
     name = 'hello_world.txt'
-
     fh = StringIO.StringIO(contents)
     fh.name = name
 
@@ -77,8 +78,10 @@ def upload_tempfile(item):
     temp_file.write(contents)
     temp_file.seek(0, os.SEEK_SET)
 
-    item.upload(temp_file.name, metadata=dict(collection='test_collection'), 
-                access_key=access, secret_key=secret)
+    item.upload(temp_file.name, metadata= {
+            'collection': 'test_collection',
+            'description': 'ℛℯα∂α♭ℓℯ ♭ʊ☂ η☺т Ѧ$☾ℐℐ, ¡ooʇ ןnɟǝsn sı uʍop-ǝpısdn' + string.whitespace,
+        }, access_key=access, secret_key=secret)
     temp_file.close()
 
     f = get_file(item.identifier, os.path.basename(temp_file.name))


### PR DESCRIPTION
- Based on discussions in #63 this change increases the cases where header values are uri encoded.
- This change does not handle filenames with non-ascii character sets.
