### PR TITLE
Fix AttributeError: 'module' object has no attribute 'poll'

### DIFF
--- a/tests/iacli/test_ia_download.py
+++ b/tests/iacli/test_ia_download.py
@@ -1,5 +1,9 @@
 import os, sys, shutil
-from subprocess import Popen, PIPE
+try:
+    from gevent.subprocess import Popen, PIPE
+except ImportError:
+    from subprocess import Popen, PIPE
+
 from time import time
 
 import pytest

--- a/tests/iacli/test_ia_list.py
+++ b/tests/iacli/test_ia_list.py
@@ -1,5 +1,8 @@
 import os, sys
-from subprocess import Popen, PIPE
+try:
+    from gevent.subprocess import Popen, PIPE
+except ImportError:
+    from subprocess import Popen, PIPE
 from time import time
 
 import pytest

--- a/tests/iacli/test_ia_metadata.py
+++ b/tests/iacli/test_ia_metadata.py
@@ -1,5 +1,8 @@
 import os, sys
-from subprocess import Popen, PIPE
+try:
+    from gevent.subprocess import Popen, PIPE
+except ImportError:
+    from subprocess import Popen, PIPE
 from time import time
 
 import pytest

--- a/tests/iacli/test_ia_mine.py
+++ b/tests/iacli/test_ia_mine.py
@@ -1,5 +1,8 @@
 import os, sys
-from subprocess import Popen, PIPE
+try:
+    from gevent.subprocess import Popen, PIPE
+except ImportError:
+    from subprocess import Popen, PIPE
 from time import time
 
 import pytest

--- a/tests/iacli/test_ia_search.py
+++ b/tests/iacli/test_ia_search.py
@@ -1,5 +1,8 @@
 import os, sys
-from subprocess import Popen, PIPE
+try:
+    from gevent.subprocess import Popen, PIPE
+except ImportError:
+    from subprocess import Popen, PIPE
 from time import time
 
 import pytest

--- a/tests/iacli/test_ia_upload.py
+++ b/tests/iacli/test_ia_upload.py
@@ -1,5 +1,8 @@
 import os, sys
-from subprocess import Popen, PIPE
+try:
+    from gevent.subprocess import Popen, PIPE
+except ImportError:
+    from subprocess import Popen, PIPE
 from time import time
 
 import pytest


### PR DESCRIPTION
gevent monkeypatches select.poll away, so normal
python subprocess module does not work.

I presume the "ia mine" feature is going to be removed
from the wrapper; but would be great to fix since
it was very confusing problem (on one box with gevent
the tests didn't work, on the other one they passed).