### PR TITLE
remove default sort order (leave at rank order)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -190,7 +190,7 @@ top 20 items matching the search 'dogs':
 
 .. code:: bash
 
-    $ ia search --parameters="page:1" --parameters="rows:20" "dogs"
+    $ ia search --parameters="page:1;rows:20" "dogs"
 
 You can use ``ia search`` to create an itemlist:
 

--- a/README.rst
+++ b/README.rst
@@ -182,6 +182,15 @@ Search
 .. code:: bash
 
     $ ia search 'subject:"market street" collection:prelinger'
+    
+By default, ``ia search`` attempts to return all items meeting the search criteria,
+and the results are sorted by item identifier. If you want to just select the top ``n``
+items, you can specify a ``page`` and ``rows`` parameter. For example, to get the 
+top 20 items matching the search 'dogs':
+
+.. code:: bash
+
+    $ ia search --parameters="page:1" --parameters="rows:20" "dogs"
 
 You can use ``ia search`` to create an itemlist:
 

--- a/internetarchive/cli/argparser.py
+++ b/internetarchive/cli/argparser.py
@@ -8,6 +8,7 @@ internetarchive.cli.argparser
 """
 from collections import defaultdict
 from xml.dom.minidom import parseString
+import re
 
 
 def get_xml_text(xml_str, tag_name=None, text=None):
@@ -22,19 +23,17 @@ def get_xml_text(xml_str, tag_name=None, text=None):
     return text
 
 
-def get_args_dict(args):
-    # Convert args list into a metadata dict.
-    args = [] if not args else args
-    metadata = defaultdict(list)
-    for md in args:
-        key, value = md.split(':', 1)
-        assert value
-        if value not in metadata[key]:
-            metadata[key].append(value)
-
-    for key in metadata:
+def get_args_dict(strings):
+    args = defaultdict(list)
+    for s in strings:
+        for (key, value) in \
+                [[x.strip() for x in re.split(r'[:=]', p, 1)]
+                    for p in re.split('[,;&]', s)]:
+            assert value
+            if value not in args[key]:
+                args[key].append(value)
+    for key in args:
         # Flatten single item lists.
-        if len(metadata[key]) <= 1:
-            metadata[key] = metadata[key][0]
-
-    return metadata
+        if len(args[key]) <= 1:
+            args[key] = args[key][0]
+    return args

--- a/internetarchive/search.py
+++ b/internetarchive/search.py
@@ -61,7 +61,9 @@ class Search(object):
 
         # Sort by score if no other sort is provided -- if page parameter is
         # not provided.
-        if 'page' not in params and not any(k.startswith('sort') for k, v in params.items()):
+        has_page_param = 'page' in params
+        has_sort_param = any(k.startswith('sort') for k, v in params.items())
+        if not (has_page_param or has_sort_param):
             default_params['sort[0]'] = 'identifier asc'
 
         self.params = default_params.copy()

--- a/internetarchive/search.py
+++ b/internetarchive/search.py
@@ -57,10 +57,6 @@ class Search(object):
         # Set retries.
         self.session._mount_http_adapter(max_retries=5)
 
-        # Sort by identifier if no other sort is provided.
-        if not any(k.startswith('sort') for k, v in params.items()):
-            default_params['sort[0]'] = 'identifier asc'
-
         self.params = default_params.copy()
         self.params.update(params)
         if not self.params.get('output'):

--- a/tests/cli/test_argparser.py
+++ b/tests/cli/test_argparser.py
@@ -20,16 +20,22 @@ def test_get_xml_text():
 def test_get_args_dict():
     test_input = [
         'collection:test_collection',
-        "description: Attention: multiple colon's",
+        "description: Attention: multiple colons",
         'unicode_test:தமிழ்',
         'subject:subject1',
         'subject:subject2',
+        'a=b&a=c&a=d',
+        'b = a , b = c , b = d',
+        'c = a ; c = b ; c = d'
     ]
     test_output = {
         'collection': 'test_collection',
-        'description': " Attention: multiple colon's",
+        'description': "Attention: multiple colons",
         'unicode_test': 'தமிழ்',
-        'subject': ['subject1', 'subject2']
+        'subject': ['subject1', 'subject2'],
+        'a': ['b', 'c', 'd'],
+        'b': ['a', 'c', 'd'],
+        'c': ['a', 'b', 'd']
     }
     args_dict = get_args_dict(test_input)
     for key, value in args_dict.items():


### PR DESCRIPTION
Currently, the `ia search` command reorders results by `identifier`. This is not the right behavior for a number of reasons:

1. The `advancedsearch.php` endpoint does states sorting is optional
2. There is no option for 'sort by relevance,' (except by explicitly providing a 'blank' sort order), so there is no way to recover the relevance sort
3. Results returned by relevance rank is the standard default for search systems

This code simply removes the default `identifier asc` sort order.