### PR TITLE
Cast all headers to string in prepare_headers

### DIFF
--- a/internetarchive/iarequest.py
+++ b/internetarchive/iarequest.py
@@ -151,7 +151,8 @@ class S3PreparedRequest(requests.models.PreparedRequest):
                 # translate two hyphens in a row (--) into an underscore (_).
                 header_key = header_key.replace('_', '--')
                 headers[header_key] = value
-        super(S3PreparedRequest, self).prepare_headers(headers)
+        super(S3PreparedRequest, self).prepare_headers(
+                {k: str(v) for k, v in headers.items()})
 
 
 class MetadataRequest(requests.models.Request):


### PR DESCRIPTION
Some headers were being passed to requests with integer values, which would cause requests to raise a InvalidHeader error (at line [799 of requests/utils.py](https://github.com/kennethreitz/requests/blob/master/requests/utils.py#L799)).  This casts all headers to string, which solves the issue.  I tested this with an upload to the Internet Archive and it avoided the error for me - was not able to get uploading to work otherwise.