### PR TITLE
Convert boolean value to the string explicitly

### DIFF
--- a/internetarchive/files.py
+++ b/internetarchive/files.py
@@ -260,7 +260,7 @@ class File(BaseFile):
                       without sending the delete request.
 
         """
-        cascade_delete = False if not cascade_delete else True
+        cascade_delete = '0' if not cascade_delete else '1'
         access_key = self.item.session.access_key if not access_key else access_key
         secret_key = self.item.session.secret_key if not secret_key else secret_key
         debug = False if not debug else debug
@@ -276,7 +276,7 @@ class File(BaseFile):
         request = iarequest.S3Request(
             method='DELETE',
             url=url,
-            headers={'x-archive-cascade-delete': int(cascade_delete)},
+            headers={'x-archive-cascade-delete': cascade_delete},
             access_key=access_key,
             secret_key=secret_key
         )


### PR DESCRIPTION
requests 2.11 is checking types of HTTP headers now (this could seen as a followup to https://github.com/jjjake/internetarchive/commit/76b5b16d1bd2c721f691ec7888d010cc27076b4a)

Fixes https://github.com/jjjake/internetarchive/issues/151