### PR TITLE
Fix minor ReST documentation issues.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -67,8 +67,11 @@ Release History
 - All search requests now require authentication via IA-S3 keys.
   You can run ``ia configure`` to generate a config file that will be used to authenticate all search requests automatically. 
   For more details refer to the following links:
-    http://internetarchive.readthedocs.io/en/latest/quickstart.html?highlight=configure#configuring
-    http://internetarchive.readthedocs.io/en/latest/api.html#configuration
+
+  http://internetarchive.readthedocs.io/en/latest/quickstart.html?highlight=configure#configuring
+
+  http://internetarchive.readthedocs.io/en/latest/api.html#configuration
+
 - Added ability to specify your own filepath in ``ia configure`` and ``internetarchive.configure()``.
 
 **Bugfixes**

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -133,7 +133,7 @@ You can use the ``--retries`` parameter to retry on errors (i.e. if IA-S3 is ove
     
     $ ia upload <identifier> file1 --retries 10
 
-Refer to `archive.org Identifiers <identifiers.html>`_ for more information on creating valid archive.org identifiers.
+Refer to `archive.org Identifiers <metadata.html#archive-org-identifiers>`_ for more information on creating valid archive.org identifiers.
 Please also read the `Internet Archive Items <items.html>`_ page before getting started.
 
 Bulk Uploading

--- a/docs/source/metadata.rst
+++ b/docs/source/metadata.rst
@@ -31,7 +31,7 @@ addeddate
 
 Contains the date on which the item was added to Internet Archive.
 
-Please use an `ISO 8601 <https://en.wikipedia.org/wiki/ISO_8601>`_ compatible format for this date.
+Please use an `ISO 8601`_ compatible format for this date.
 For instance, these are all valid date formats:
 
 - YYYY
@@ -95,7 +95,7 @@ date
 
 The publication, production or other similar date of this item. 
 
-Please use an `ISO 8601 <https://en.wikipedia.org/wiki/ISO_8601>`_ compatible format for this date.
+Please use an `ISO 8601`_ compatible format for this date.
 
 description
 ^^^^^^^^^^^
@@ -186,7 +186,7 @@ publicdate
 Items which have had their metadata included in the Internet Archive search engine index are considered to be public.
 The date the metadata is added to the index is the public date for the item.
 
-Please use an `ISO 8601 <https://en.wikipedia.org/wiki/ISO_8601>`_ compatible format for this date.
+Please use an `ISO 8601`_ compatible format for this date.
 For instance, these are all valid date formats:
 
 While it is possible to set the ``publicdate`` metadata value it is not recommended.
@@ -238,7 +238,7 @@ updatedate
 The date on which an update was made to the item.
 This field is repeatable.
 
-Please use an `ISO 8601 <http://en.wikipedia.org/wiki/ISO_8601>`_ compatible format for this date.
+Please use an `ISO 8601`_ compatible format for this date.
 
 While it is possible to set the ``publicdate`` metadata value it is not recommended.
 This value is typically set by automated processes.
@@ -268,3 +268,5 @@ Custom Metadata Fields
 Internet Archive strives to be metadata agnostic, enabling users to define the metadata format which best suits the needs of their material.
 In addition to the standard metadata fields listed above you may also define as many custom metadata fields as you require.
 These metadata fields can be defined ad hoc at item creation or metadata editing time and do not have to be defined in advance.
+
+.. _ISO 8601: https://en.wikipedia.org/wiki/ISO_8601

--- a/docs/source/troubleshooting.rst
+++ b/docs/source/troubleshooting.rst
@@ -20,21 +20,21 @@ If you are using a Python version earlier than 2.7.9, you might see ``InsecurePl
     2. Install or upgrade the following Python modules as `documented here <https://urllib3.readthedocs.org/en/latest/security.html#installing-urllib3-with-sni-support-and-certificates>`_: ``PyOpenSSL``, ``ndg-httpsclient``, and ``pyasn1``.
     3. Use HTTP to make insecure requests in one of the following ways:
            + Adding the following lines to your ``ia.ini`` config file (usually located at ``~/.config/ia.ini`` or ``~/.ia.ini``):
-           .. code:: bash
+               .. code:: bash
 
-             [general]
-             secure = false
+                 [general]
+                 secure = false
 
            + In the Python interface, using a config dict:
 
-           .. code:: python
+               .. code:: python
 
-             >>> from internetarchive import get_item
-             >>> config = dict(general=dict(secure=False))
-             >>> item = get_item('<identifier>', config=config)
+                 >>> from internetarchive import get_item
+                 >>> config = dict(general=dict(secure=False))
+                 >>> item = get_item('<identifier>', config=config)
 
            + In the command-line interface, use the ``--insecure`` option:
 
-           .. code:: bash
+               .. code:: bash
 
-             $ ia --insecure download <identifier>
+                 $ ia --insecure download <identifier>


### PR DESCRIPTION
Sphinx 1.4.4 generates the following messages when building docs

    WARNING: nonlocal image URI found: https://travis-ci.org/jjjake/internetarchive.svg
    WARNING: Duplicate explicit target name: "iso 8601"
    WARNING: Bullet list ends without a blank line; unexpected unindent.
    error: HISTORY.rst:70: ERROR: Unexpected indentation.

This fixes the bottom three messages, only leaving the Travis CI badge problem
unsolved.

While here, fix a broken link.