### PR TITLE
Handle case where invalid media-type is returned.

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -8,6 +8,11 @@ Development Lead
 
 - Jake Johnson <jake@archive.org>
 
+Contributors
+------------
+
+- Bryce Drennan <internetarchive@brycedrennan.com>
+
 Patches and Suggestions
 -----------------------
 

--- a/internetarchive/session.py
+++ b/internetarchive/session.py
@@ -213,7 +213,10 @@ class ArchiveSession(requests.sessions.Session):
                          'retrieving now.'.format(identifier))
             item_metadata = self.get_metadata(identifier, request_kwargs)
         mediatype = item_metadata.get('metadata', {}).get('mediatype')
-        item_class = self.ITEM_MEDIATYPE_TABLE.get(mediatype, Item)
+        try:
+            item_class = self.ITEM_MEDIATYPE_TABLE.get(mediatype, Item)
+        except TypeError:
+            item_class = Item
         return item_class(self, identifier, item_metadata)
 
     def get_metadata(self, identifier, request_kwargs=None):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -73,7 +73,10 @@ def call_cmd(cmd, expected_exit_code=0):
     stdout, stderr = proc.communicate()
     stdout = stdout.decode('utf-8').strip()
     stderr = stderr.decode('utf-8').strip()
-    assert proc.returncode == expected_exit_code
+    if proc.returncode != expected_exit_code:
+        print(stdout)
+        print(stderr)
+        assert proc.returncode == expected_exit_code
     return (stdout, stderr)
 
 

--- a/tests/test_bad_data.py
+++ b/tests/test_bad_data.py
@@ -1,0 +1,12 @@
+from internetarchive.api import get_item
+from tests.conftest import IaRequestsMock
+
+
+def test_bad_mediatype():
+    # this identifier actually has this malformed data
+    ident = 'CIA-RDP96-00789R000700210007-5'
+    body = '{"metadata": {"mediatype":["texts","texts"]}}'
+    with IaRequestsMock() as rsps:
+        rsps.add_metadata_mock(ident, body=body)
+        # should complete without error
+        get_item(ident)


### PR DESCRIPTION
`TypeError: unhashable type: 'list'` was happening if the metadata had a non-hashable mediatype.
See identifier `CIA-RDP96-00789R000700210007-5` for an example.

 - add test for this case. 
 - added myself to contributors section