### PR TITLE
Add the packaging metadata to build the ia snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,19 @@
+name: ia
+version: master
+summary: A Command-Line Interface to Archive.org
+description: |
+  This package installs a command-line tool named ia for using Archive.org
+  from the command-line.
+
+grade: devel # must be 'stable' to release into candidate/stable channels
+confinement: strict
+
+apps:
+  ia:
+    command: ia
+    plugs: [network, home, removable-media]
+
+parts:
+  internetarchive:
+    source: .
+    plugin: python


### PR DESCRIPTION
This is a package for the secure installation of apps that works in most Linux distributions.
Landing it upstream will enable builds that then can be distributed to many users through the Ubuntu store.