### PR TITLE
Enable client to DL on-the-fly archive_marc.xml

### DIFF
--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -228,7 +228,7 @@ See ``ia help download`` for more details.
 Downloading On-The-Fly Files
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Some files on archive.org are generated on-the-fly as requested. This currently includes non-original files of the formats EPUB, MOBI, and DAISY. These files can be downloaded using the ``--on-the-fly`` parameter:
+Some files on archive.org are generated on-the-fly as requested. This currently includes non-original files of the formats EPUB, MOBI, DAISY, and archive.org's own MARC XML. These files can be downloaded using the ``--on-the-fly`` parameter:
 
 .. code:: bash
 

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -186,7 +186,7 @@ Or, a list of formats::
 Downloading On-The-Fly Files
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Some files on archive.org are generated on-the-fly as requested. This currently includes non-original files of the formats EPUB, MOBI, and DAISY. These files can be downloaded using the ``on_the_fly`` parameter::
+Some files on archive.org are generated on-the-fly as requested. This currently includes non-original files of the formats EPUB, MOBI, DAISY, and archive.org's own MARC XML. These files can be downloaded using the ``on_the_fly`` parameter::
 
     >>> download('goodytwoshoes00newyiala', verbose=True, formats='EPUB', on_the_fly=True)
     goodytwoshoes00newyiala:

--- a/internetarchive/cli/ia_download.py
+++ b/internetarchive/cli/ia_download.py
@@ -48,8 +48,8 @@ options:
                                                  ia metadata --formats <identifier>
 
     --on-the-fly                             Download on-the-fly files, as well as other matching
-                                             files. on-the-fly files includ derivative EPUB, MOBI
-                                             and DAISY files [default: True].
+                                             files. on-the-fly files include derivative EPUB, MOBI
+                                             and DAISY files [default: False].
     --no-directories                         Download files into working directory. Do not
                                              create item directories.
     --destdir=<dir>                          The destination directory to download files

--- a/internetarchive/item.py
+++ b/internetarchive/item.py
@@ -244,6 +244,7 @@ class Item(BaseItem):
                 '{0}.epub'.format(self.identifier),
                 '{0}.mobi'.format(self.identifier),
                 '{0}_daisy.zip'.format(self.identifier),
+                '{0}_archive_marc.xml'.format(self.identifier),
             ]
             for f in otf_files:
                 item_files.append(dict(name=f, otf=True))


### PR DESCRIPTION
Here is a pretty simple PR to allow archive.org's own Full catalog record MARCXML to be downloaded.

I have also changed the documented default for `--on-the-fly` to `False` in cli/ia_download.py  When I use CLI `ia download`, the behaviour is to exclude on-the-fly files, unless the parameter is specifically supplied.