### PR TITLE
BUGFIX: modify_metadata debug + other args not honoured

### DIFF
--- a/internetarchive/api.py
+++ b/internetarchive/api.py
@@ -195,8 +195,14 @@ def modify_metadata(identifier, metadata,
               debug is ``True``.
     """
     item = get_item(identifier, **get_item_kwargs)
-    return item.modify_metadata(metadata, target, append, priority, access_key,
-                                secret_key, debug, request_kwargs)
+    return item.modify_metadata(metadata,
+                                target=target,
+                                append=append,
+                                priority=priority,
+                                access_key=access_key,
+                                secret_key=secret_key,
+                                debug=debug,
+                                request_kwargs=request_kwargs)
 
 
 def upload(identifier, files,


### PR DESCRIPTION
@jjjake, I found a bug where the `modify_metadata` debug param is not being honoured. I accidentally sent a live request while testing out the effect of `append=True` on list values. I had used `append` incorrectly, but the record was modified, which I wasn't expecting :(   

`Item.modify_metadata()` was being called from api.py using positional arguments, but `append_list` is missed, so the optional args `priority`, `access_key`, `secret_key`, `debug`, and `request_kwargs` were all offset by one. This PR fixes that.

I can't find documentation for `append_list`, but it seems like it should be added to the api `modify_metadata`. It sounds like it might be do what I thought `append` did, but that's a separate improvement :) This just fixes the issue and allows the current args to be passed through correctly. 
