### PR TITLE
Add --no-change-timestamp flag

### DIFF
--- a/internetarchive/cli/ia_download.py
+++ b/internetarchive/cli/ia_download.py
@@ -55,6 +55,8 @@ options:
     --destdir=<dir>                          The destination directory to download files
                                              and item directories to.
     -s, --stdout                             Write file contents to stdout.
+    --no-change-timestamp                    Don't change the timestamp of downloaded files to reflect
+                                             the source material.
 """
 from __future__ import print_function, absolute_import
 import os
@@ -94,6 +96,7 @@ def main(argv, session):
         '--retries': Use(lambda x: x[0]),
         '--search-parameters': Use(lambda x: get_args_dict(x, query_string=True)),
         '--on-the-fly': Use(bool),
+        '--no-change-timestamp': Use(bool)
     })
 
     # Filenames should be unicode literals. Support PY2 and PY3.
@@ -201,6 +204,7 @@ def main(argv, session):
             item_index=item_index,
             ignore_errors=True,
             on_the_fly=args['--on-the-fly'],
+            no_change_timestamp=args['--no-change-timestamp']
         )
         if _errors:
             errors.append(_errors)

--- a/internetarchive/files.py
+++ b/internetarchive/files.py
@@ -126,7 +126,7 @@ class File(BaseFile):
 
     def download(self, file_path=None, verbose=None, silent=None, ignore_existing=None,
                  checksum=None, destdir=None, retries=None, ignore_errors=None,
-                 fileobj=None, return_responses=None):
+                 fileobj=None, return_responses=None, no_change_timestamp=None):
         """Download the file into the current working directory.
 
         :type file_path: str
@@ -164,6 +164,11 @@ class File(BaseFile):
         :param return_responses: (optional) Rather than downloading files to disk, return
                                  a list of response objects.
 
+        :type no_change_timestamp: bool
+        :param no_change_timestamp: (optional) If True, leave the time stamp as the
+                                    current time instead of changing it to that given in
+                                    the original archive.
+
         :rtype: bool
         :returns: True if file was successfully downloaded.
         """
@@ -173,6 +178,8 @@ class File(BaseFile):
         retries = 2 if not retries else retries
         ignore_errors = False if not ignore_errors else ignore_errors
         return_responses = False if not return_responses else return_responses
+        no_change_timestamp = False if not no_change_timestamp else no_change_timestamp
+
         if (fileobj and silent is None) or silent is not False:
             silent = True
         else:
@@ -266,6 +273,8 @@ class File(BaseFile):
 
         # Set mtime with mtime from files.xml.
         try:
+            if not no_change_timestamp:
+                # If we haven't been told to leave the timestamp unchanged...
             os.utime(file_path.encode('utf-8'), (0, self.mtime))
         except OSError:
             # Probably file-like object, e.g. sys.stdout.

--- a/internetarchive/files.py
+++ b/internetarchive/files.py
@@ -273,7 +273,6 @@ class File(BaseFile):
 
         # Set mtime with mtime from files.xml.
             if not no_change_timestamp:
-                # If we haven't been told to leave the timestamp unchanged...
             try:
             os.utime(file_path.encode('utf-8'), (0, self.mtime))
         except OSError:

--- a/internetarchive/files.py
+++ b/internetarchive/files.py
@@ -272,9 +272,9 @@ class File(BaseFile):
                 raise exc
 
         # Set mtime with mtime from files.xml.
-        try:
             if not no_change_timestamp:
                 # If we haven't been told to leave the timestamp unchanged...
+            try:
             os.utime(file_path.encode('utf-8'), (0, self.mtime))
         except OSError:
             # Probably file-like object, e.g. sys.stdout.

--- a/internetarchive/files.py
+++ b/internetarchive/files.py
@@ -272,12 +272,13 @@ class File(BaseFile):
                 raise exc
 
         # Set mtime with mtime from files.xml.
-            if not no_change_timestamp:
+        if not no_change_timestamp:
+            # If we want to set the timestamp to that of the original archive...
             try:
-            os.utime(file_path.encode('utf-8'), (0, self.mtime))
-        except OSError:
-            # Probably file-like object, e.g. sys.stdout.
-            pass
+                os.utime(file_path.encode('utf-8'), (0, self.mtime))
+            except OSError:
+                # Probably file-like object, e.g. sys.stdout.
+                pass
 
         msg = 'downloaded {0}/{1} to {2}'.format(self.identifier,
                                                  self.name,

--- a/internetarchive/item.py
+++ b/internetarchive/item.py
@@ -414,7 +414,8 @@ class Item(BaseItem):
                 print(f.url)
                 continue
             r = f.download(path, verbose, silent, ignore_existing, checksum, destdir,
-                           retries, ignore_errors, None, return_responses)
+                           retries, ignore_errors, None, return_responses,
+                           no_change_timestamp)
             if return_responses:
                 responses.append(r)
             if r is False:

--- a/internetarchive/item.py
+++ b/internetarchive/item.py
@@ -282,7 +282,8 @@ class Item(BaseItem):
                  item_index=None,
                  ignore_errors=None,
                  on_the_fly=None,
-                 return_responses=None):
+                 return_responses=None,
+                 no_change_timestamp=None):
         """Download files from an item.
 
         :param files: (optional) Only download files matching given file names.
@@ -339,6 +340,11 @@ class Item(BaseItem):
         :param return_responses: (optional) Rather than downloading files to disk, return
                                  a list of response objects.
 
+        :type no_change_timestamp: bool
+        :param no_change_timestamp: (optional) If True, leave the time stamp as the
+                                    current time instead of changing it to that given in
+                                    the original archive.
+
         :rtype: bool
         :returns: True if if all files have been downloaded successfully.
         """
@@ -350,6 +356,7 @@ class Item(BaseItem):
         checksum = False if checksum is None else checksum
         no_directory = False if no_directory is None else no_directory
         return_responses = False if not return_responses else True
+        no_change_timestamp = False if not no_change_timestamp else no_change_timestamp
 
         if not dry_run:
             if item_index and verbose is True:

--- a/tests/cli/test_ia_download.py
+++ b/tests/cli/test_ia_download.py
@@ -86,9 +86,6 @@ def test_destdir(tmpdir_ch):
            'nasa nasa_meta.xml')
     call_cmd(cmd)
     assert files_downloaded('dir2') == set(['nasa_meta.xml'])
-           'nasa nasa_meta.xml')
-    call_cmd(cmd)
-    assert files_downloaded('dir2') == set(['nasa_meta.xml'])
 
 
 def test_no_change_timestamp(tmpdir_ch):

--- a/tests/cli/test_ia_download.py
+++ b/tests/cli/test_ia_download.py
@@ -94,7 +94,7 @@ def test_no_change_timestamp(tmpdir_ch):
     now = time.time()
     call_cmd('ia --insecure download --no-change-timestamp nasa')
 
-    for path, dirnames, filenames in os.walk(tmpdir_ch):
+    for path, dirnames, filenames in os.walk(str(tmpdir_ch)):
         for d in dirnames:
             p = os.path.join(path, d)
             assert os.stat(p).st_mtime >= now

--- a/tests/cli/test_ia_download.py
+++ b/tests/cli/test_ia_download.py
@@ -1,4 +1,6 @@
 import sys
+import os
+import time
 
 from tests.conftest import call_cmd, NASA_EXPECTED_FILES, files_downloaded
 
@@ -84,3 +86,22 @@ def test_destdir(tmpdir_ch):
            'nasa nasa_meta.xml')
     call_cmd(cmd)
     assert files_downloaded('dir2') == set(['nasa_meta.xml'])
+           'nasa nasa_meta.xml')
+    call_cmd(cmd)
+    assert files_downloaded('dir2') == set(['nasa_meta.xml'])
+
+
+def test_no_change_timestamp(tmpdir_ch):
+    # TODO: Handle the case of daylight savings time
+
+    now = time.time()
+    call_cmd('ia --insecure download --no-change-timestamp nasa')
+
+    for path, dirnames, filenames in os.walk(tmpdir_ch):
+        for d in dirnames:
+            p = os.path.join(path, d)
+            assert os.stat(p).st_mtime >= now
+
+        for f in filenames:
+            p = os.path.join(path, f)
+            assert os.stat(p).st_mtime >= now


### PR DESCRIPTION
Right now, when a file is downloaded its timestamp on the file system is changed to reflect that on the Internet Archive.  This optional flag prevents that.

I added this because I'm downloading files onto an HPC cluster's scratch space.  Every day, the cluster deletes all files that haven't been modified in 30 days.  That implies that anything I download from the Internet Archive will be deleted unless I babysit the download and change the time stamp at the end.