### PR TITLE
fix warnings in docs builds

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -28,6 +28,8 @@ User's Guide
     installation
     quickstart
     cli
+    jq
+    metadata
     api
     updates
     troubleshooting

--- a/docs/source/jq.rst
+++ b/docs/source/jq.rst
@@ -1,5 +1,3 @@
-.. _jq:
-
 Using jq with ia
 ================
 
@@ -227,7 +225,7 @@ Get the identifiers for all of your redrows:
     $ ia tasks --json | jq -r 'select(.row_type == "red").identifier'
 
 TODO
-____
+----
 
 Recipes to document, work in progress...
 


### PR DESCRIPTION
A clean build of the docs yielded the following errors:

```
reading sources... [100%] updates                                               
/home/anarcat/src/internetarchive/docs/source/jq.rst:4: WARNING: Duplicate explicit target name: "jq".
/home/anarcat/src/internetarchive/docs/source/jq.rst:229: WARNING: Title level inconsistent:

TODO
____
looking for now-outdated files... none found
pickling environment... done
checking consistency... /home/anarcat/src/internetarchive/docs/source/jq.rst: WARNING: document isn't included in any toctree
/home/anarcat/src/internetarchive/docs/source/metadata.rst: WARNING: document isn't included in any toctree
```

This patch adds the missing documents to the toctree and fixes the todo title.