### PR TITLE
Improve handling of full items

### DIFF
--- a/internetarchive/cli/ia_upload.py
+++ b/internetarchive/cli/ia_upload.py
@@ -61,7 +61,7 @@ from copy import deepcopy
 
 import six
 from docopt import docopt, printable_usage
-from requests.exceptions import HTTPError
+from requests.exceptions import HTTPError, ConnectionError
 from schema import Schema, Use, Or, And, SchemaError
 
 from internetarchive.cli.argparser import get_args_dict, convert_str_list_to_unicode
@@ -87,6 +87,10 @@ def _upload_files(item, files, upload_kwargs, prev_identifier=None, archive_sess
         responses += response
     except HTTPError as exc:
         responses += [exc.response]
+    except ConnectionError as exc:
+        print("Received ConnectionError while uploading. If this happens consistently,",
+              " the item you're uploading to might be full. Run --status-check!")
+        raise
     finally:
         # Debug mode.
         if upload_kwargs['debug']:

--- a/internetarchive/cli/ia_upload.py
+++ b/internetarchive/cli/ia_upload.py
@@ -67,6 +67,7 @@ from schema import Schema, Use, Or, And, SchemaError
 from internetarchive.cli.argparser import get_args_dict, convert_str_list_to_unicode
 from internetarchive.session import ArchiveSession
 from internetarchive.utils import validate_ia_identifier, get_s3_xml_text
+from internetarchive import get_item
 
 # Only import backports.csv for Python2 (in support of FreeBSD port).
 PY2 = sys.version_info[0] == 2
@@ -178,6 +179,10 @@ def main(argv, session):
         if session.s3_is_overloaded():
             print('warning: {0} is over limit, and not accepting requests. '
                   'Expect 503 SlowDown errors.'.format(args['<identifier>']),
+                  file=sys.stderr)
+            sys.exit(1)
+        elif get_item('{0}'.format(args['<identifier>'])).item_size >= 1099511627776:
+            print('warning: {0} is full and cannot accept uploads.'.format(args['<identifier>']),
                   file=sys.stderr)
             sys.exit(1)
         else:


### PR DESCRIPTION
Show a warning message when an upload fails due to a ConnectionError, as is the case when the item is full. `--status-check` now checks for this. These two changes make the underlying issue in #290 more clear.

This is just about the minimum useful PR I could put together in a short time. I'm not really familiar with all the different uses of `ia`, so wasn't really sure how to properly signal the failure of a single upload for bulk uploads and the like. I'd like to improve on this later if time allows, but this is better than nothing.