### PR TITLE
Abandon MD5, adopt SHA-1

### DIFF
--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -151,7 +151,7 @@ By default, the :func:`download <internetarchive.download>` function sets the ``
      skipping nasa/nasa_archive.torrent, file already exists based on length and date.
      skipping nasa/nasa_files.xml, file already exists based on length and date.
 
-Alternatively, you can skip files based on md5 checksums. This is will take longer because checksums will need to be calculated for every file already downloaded, but will be safer::
+Alternatively, you can skip files based on SHA-1 checksums. This is will take longer because checksums will need to be calculated for every file already downloaded, but will be safer::
 
     >>> download('nasa', verbose=True, checksum=True)
     nasa:

--- a/internetarchive/api.py
+++ b/internetarchive/api.py
@@ -255,8 +255,8 @@ def upload(identifier, files,
     :param verbose: (optional) Display upload progress.
 
     :type verify: bool
-    :param verify: (optional) Verify local MD5 checksum matches the MD5 checksum of the
-                   file received by IAS3.
+    :param verify: (optional) Verify local SHA-1 checksum matches the SHA-1 checksum of
+                   the file received by IAS3.
 
     :type checksum: bool
     :param checksum: (optional) Skip uploading files based on checksum.

--- a/internetarchive/files.py
+++ b/internetarchive/files.py
@@ -224,9 +224,9 @@ class File(BaseFile):
                 return
             elif checksum:
                 with open(file_path, 'rb') as fp:
-                    md5_sum = utils.get_md5(fp)
+                    sha1_sum = utils.get_sha1(fp)
 
-                if md5_sum == self.md5:
+                if sha1_sum == self.sha1:
                     msg = ('skipping {0}, '
                            'file already exists based on checksum.'.format(file_path))
                     log.info(msg)

--- a/internetarchive/item.py
+++ b/internetarchive/item.py
@@ -45,8 +45,9 @@ from requests import Response
 from clint.textui import progress
 from requests.exceptions import HTTPError
 
-from internetarchive.utils import IdentifierListAsItems, get_sha1, chunk_generator, \
-    IterableToFileAdapter, iter_directory, recursive_file_count, norm_filepath
+from internetarchive.utils import IdentifierListAsItems, get_sha1, get_md5, \
+    chunk_generator, IterableToFileAdapter, iter_directory, recursive_file_count, \
+    norm_filepath
 from internetarchive.files import File
 from internetarchive.iarequest import MetadataRequest, S3Request
 from internetarchive.utils import get_s3_xml_text, get_file_size, is_dir

--- a/internetarchive/item.py
+++ b/internetarchive/item.py
@@ -45,7 +45,7 @@ from requests import Response
 from clint.textui import progress
 from requests.exceptions import HTTPError
 
-from internetarchive.utils import IdentifierListAsItems, get_md5, chunk_generator, \
+from internetarchive.utils import IdentifierListAsItems, get_sha1, chunk_generator, \
     IterableToFileAdapter, iter_directory, recursive_file_count, norm_filepath
 from internetarchive.files import File
 from internetarchive.iarequest import MetadataRequest, S3Request

--- a/internetarchive/item.py
+++ b/internetarchive/item.py
@@ -678,7 +678,7 @@ class Item(BaseItem):
                              being derived after upload.
 
         :type verify: bool
-        :param verify: (optional) Verify local MD5 checksum matches the MD5
+        :param verify: (optional) Verify local SHA-1 checksum matches the SHA-1
                        checksum of the file received by IAS3.
 
         :type checksum: bool
@@ -728,7 +728,7 @@ class Item(BaseItem):
         request_kwargs = {} if request_kwargs is None else request_kwargs
         if 'timeout' not in request_kwargs:
             request_kwargs['timeout'] = 120
-        md5_sum = None
+        sha1_sum = None
 
         if not hasattr(body, 'read'):
             filename = body
@@ -756,9 +756,9 @@ class Item(BaseItem):
 
         # Skip based on checksum.
         if checksum:
-            md5_sum = get_md5(body)
+            sha1_sum = get_sha1(body)
             ia_file = self.get_file(key)
-            if (not self.tasks) and (ia_file) and (ia_file.md5 == md5_sum):
+            if (not self.tasks) and (ia_file) and (ia_file.sha1 == sha1_sum):
                 log.info('{f} already exists: {u}'.format(f=key, u=url))
                 if verbose:
                     print(' {f} already exists, skipping.'.format(f=key))
@@ -778,9 +778,7 @@ class Item(BaseItem):
 
         # require the Content-MD5 header when delete is True.
         if verify or delete:
-            if not md5_sum:
-                md5_sum = get_md5(body)
-            headers['Content-MD5'] = md5_sum
+            headers['Content-MD5'] = get_md5(body)
 
         def _build_request():
             body.seek(0, os.SEEK_SET)

--- a/internetarchive/utils.py
+++ b/internetarchive/utils.py
@@ -83,8 +83,8 @@ def norm_filepath(fp):
     return fp
 
 
-def get_sha1(file_object):
-    m = hashlib.sha1()
+def get_hash(file_object, hash_name):
+    m = hashlib.new(hash_name)
     while True:
         data = file_object.read(8192)
         if not data:
@@ -92,6 +92,14 @@ def get_sha1(file_object):
         m.update(data)
     file_object.seek(0, os.SEEK_SET)
     return m.hexdigest()
+
+
+def get_sha1(file_object):
+    return get_hash(file_object, 'sha1')
+
+
+def get_md5(file_object):
+    return get_hash(file_object, 'md5')
 
 
 def chunk_generator(fp, chunk_size):

--- a/internetarchive/utils.py
+++ b/internetarchive/utils.py
@@ -83,8 +83,8 @@ def norm_filepath(fp):
     return fp
 
 
-def get_md5(file_object):
-    m = hashlib.md5()
+def get_sha1(file_object):
+    m = hashlib.sha1()
     while True:
         data = file_object.read(8192)
         if not data:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -32,10 +32,10 @@ def test_validate_ia_identifier():
         assert isinstance(exc, AssertionError)
 
 
-def test_get_md5():
+def test_get_sha1():
     with open(__file__, 'rb') as fp:
-        md5 = internetarchive.utils.get_md5(fp)
-    assert isinstance(md5, six.string_types)
+        sha1 = internetarchive.utils.get_sha1(fp)
+    assert isinstance(sha1, six.string_types)
 
 
 def test_map2x():


### PR DESCRIPTION
Tentatively implements #315 (use SHA-1 instead of MD5 everywhere where possible).

Turns out it's not as easy to switch to SHA-1 as I thought, mainly because of the very annoying `Content-MD5` HTTP header. Right now there are two separate functions `get_sha1` and `get_md5`. This means that when uploading files, if `verify` is set or the local files are deleted after upload, then each file will be read twice, once for SHA-1 and once for MD5. The hashes could be calculated at the same time. Please advise if this is a good idea.