### PR TITLE
remove backports requirement for newer python releases

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,8 +45,6 @@ setup(
         'schema>=0.4.0',
         'backports.csv < 1.07;python_version<"2.7"',
         'backports.csv < 1.07;python_version<"3.4"',
-        'backports.csv;python_version>="2.7"',
-        'backports.csv;python_version>="3.4"',
         'total-ordering;python_version<"2.7"',
     ],
     classifiers=[


### PR DESCRIPTION
The backports.csv requirement makes no sense in Python releases after
3.4: it's part of the standard library and works fine. Remove that
requirement from 3.5 and later, as it breaks the install on Debian and
probably other platforms.

Closes: #295