### PR TITLE
always close body after upload request

### DIFF
--- a/internetarchive/item.py
+++ b/internetarchive/item.py
@@ -966,11 +966,9 @@ class Item(BaseItem):
                         'local copy'.format(i=self.identifier, f=key))
                     body.close()
                     os.remove(filename)
-                body.close()
                 response.close()
                 return response
             except HTTPError as exc:
-                body.close()
                 msg = get_s3_xml_text(exc.response.content)
                 error_msg = (' error uploading {0} to {1}, '
                              '{2}'.format(key, self.identifier, msg))
@@ -979,6 +977,8 @@ class Item(BaseItem):
                     print(' error uploading {0}: {1}'.format(key, msg), file=sys.stderr)
                 # Raise HTTPError with error message.
                 raise type(exc)(error_msg, response=exc.response, request=exc.request)
+            finally:
+                body.close()
 
     def upload(self, files,
                metadata=None,


### PR DESCRIPTION
I think in the case of exceptions other than HTTPError, `body` would not be closed. This fixed that.