### PR TITLE
replaced sys.*.write calls with print

### DIFF
--- a/internetarchive/cli/ia_delete.py
+++ b/internetarchive/cli/ia_delete.py
@@ -96,7 +96,7 @@ def main(argv, session):
         args['--header']['x-archive-keep-old-version'] = '1'
 
     if verbose:
-        sys.stdout.write('Deleting files from {0}\n'.format(item.identifier))
+        print('Deleting files from {0}'.format(item.identifier))
 
     if args['--all']:
         files = [f for f in item.get_files()]
@@ -118,7 +118,7 @@ def main(argv, session):
         files = list(item.get_files(fnames))
 
     if not files:
-        sys.stderr.write(' warning: no files found, nothing deleted.\n')
+        print(' warning: no files found, nothing deleted.', file=sys.stderr)
         sys.exit(1)
 
     errors = False
@@ -126,13 +126,12 @@ def main(argv, session):
     for f in files:
         if not f:
             if verbose:
-                sys.stderr.write(' error: "{0}" does not exist\n'.format(f.name))
+                print(' error: "{0}" does not exist'.format(f.name), file=sys.stderr)
             errors = True
         if any(f.name.endswith(s) for s in no_delete):
             continue
         if args['--dry-run']:
-            sys.stdout.write(' will delete: {0}/{1}\n'.format(item.identifier,
-                                                              f.name.encode('utf-8')))
+            print(' will delete: {0}/{1}'.format(item.identifier, f.name))
             continue
         try:
             resp = f.delete(verbose=verbose,

--- a/internetarchive/cli/ia_download.py
+++ b/internetarchive/cli/ia_download.py
@@ -114,8 +114,8 @@ def main(argv, session):
                 raise(SchemaError(None, '--glob and --format cannot be used together.'))
 
     except SchemaError as exc:
-        sys.stderr.write('{0}\n{1}\n'.format(
-            str(exc), printable_usage(__doc__)))
+        print('{0}\n{1}'.format(
+            str(exc), printable_usage(__doc__)), file=sys.stderr)
         sys.exit(1)
 
     retries = int(args['--retries'])
@@ -130,8 +130,8 @@ def main(argv, session):
                                            params=args['--search-parameters'])
             total_ids = _search.num_found
             if total_ids == 0:
-                print('error: the query "{0}" '
-                      'returned no results'.format(args['--search']), file=sys.stderr)
+                print('error: the query "{0}" returned no results'.format(
+                    args['--search']), file=sys.stderr)
                 sys.exit(1)
             ids = _search
         except ValueError as e:
@@ -163,8 +163,8 @@ def main(argv, session):
             try:
                 assert len(f) == 1
             except AssertionError:
-                sys.stderr.write('error: {0}/{1} does not exist!\n'.format(
-                    identifier, args['<file>'][0]))
+                print('error: {0}/{1} does not exist!'.format(
+                    identifier, args['<file>'][0]), file=sys.stderr)
                 sys.exit(1)
             if six.PY2:
                 stdout_buf = sys.stdout

--- a/internetarchive/cli/ia_upload.py
+++ b/internetarchive/cli/ia_upload.py
@@ -168,10 +168,10 @@ def main(argv, session):
             collection_id = collection_id[0]
         collection = session.get_item(collection_id)
         if not collection.exists:
-            sys.stderr.write(
-                'You must upload to a collection that exists. '
-                '"{0}" does not exist.\n{1}\n'.format(collection_id,
-                                                      printable_usage(__doc__)))
+            print('You must upload to a collection that exists. '
+                  '"{0}" does not exist.\n{1}'.format(collection_id,
+                                                      printable_usage(__doc__)),
+                  file=sys.stderr)
             sys.exit(1)
 
     # Status check.


### PR DESCRIPTION
- consistency
- this also fixes some tiny output formatting errors (like mixed str/bytes)

For example in ia_delete this resulted in output like "asd/b'qwe'"