### PR TITLE
Clarify CLI download syntax for multiple formats

### DIFF
--- a/internetarchive/cli/ia_download.py
+++ b/internetarchive/cli/ia_download.py
@@ -41,7 +41,8 @@ options:
     -g, --glob=<pattern>                     Only download files whose filename matches the
                                              given glob pattern.
     -f, --format=<format>...                 Only download files of the specified format.
-                                             Use this option multiple times to download multiple formats.
+                                             Use this option multiple times to download multiple
+                                             formats.
                                              You can use the following command to retrieve
                                              a list of file formats contained within a given
                                              item:

--- a/internetarchive/cli/ia_download.py
+++ b/internetarchive/cli/ia_download.py
@@ -40,7 +40,8 @@ options:
     -P, --search-parameters=<key:value>...   Download items returned from a specified search query.
     -g, --glob=<pattern>                     Only download files whose filename matches the
                                              given glob pattern.
-    -f, --format=<format>...                 Only download files of the specified format(s).
+    -f, --format=<format>...                 Only download files of the specified format.
+                                             Use this option multiple times to download multiple formats.
                                              You can use the following command to retrieve
                                              a list of file formats contained within a given
                                              item:


### PR DESCRIPTION
With the existing documentation, it wasn't clear to me how to download multiple formats at once; this PR attempts to clarify it.