### PR TITLE
Bump six version requirement

### DIFF
--- a/pex-requirements.txt
+++ b/pex-requirements.txt
@@ -2,6 +2,6 @@ requests>=2.9.1,<3.0.0
 jsonpatch>=0.4
 docopt>=0.6.0,<0.7.0
 tqdm>=4.0.0
-six>=1.0.0,<2.0.0
+six>=1.13.0,<2.0.0
 schema>=0.4.0
 backports.csv

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
         'jsonpatch>=0.4',
         'docopt>=0.6.0,<0.7.0',
         'tqdm>=4.0.0',
-        'six>=1.0.0,<2.0.0',
+        'six>=1.13.0,<2.0.0',
         'schema>=0.4.0',
         'backports.csv < 1.07;python_version<"3.4"',
     ],


### PR DESCRIPTION
The module six.moves.collections_abc, added in commit 170c9639c0394e40d249f025e86b3ef79f4c4069, only exists since six version 1.13.0.