### PR TITLE
Validate identifiers in spreadsheet before uploading file

### DIFF
--- a/internetarchive/api.py
+++ b/internetarchive/api.py
@@ -224,6 +224,7 @@ def upload(identifier, files,
            retries=None,
            retries_sleep=None,
            debug=None,
+           validate_identifier=None,
            request_kwargs=None,
            **get_item_kwargs):
     """Upload files to an item. The item will be created if it does not exist.
@@ -276,6 +277,10 @@ def upload(identifier, files,
     :param debug: (optional) Set to True to print headers to stdout, and exit without
                   sending the upload request.
 
+    :type validate_identifier: bool
+    :param validate_identifier: (optional) Set to True to validate the identifier before 
+                                uploading the file.
+
     :param \*\*kwargs: Optional arguments that ``get_item`` takes.
 
     :returns: A list of :py:class:`requests.Response` objects.
@@ -294,6 +299,7 @@ def upload(identifier, files,
                        retries=retries,
                        retries_sleep=retries_sleep,
                        debug=debug,
+                       validate_identifier=validate_identifier,
                        request_kwargs=request_kwargs)
 
 

--- a/internetarchive/api.py
+++ b/internetarchive/api.py
@@ -278,7 +278,7 @@ def upload(identifier, files,
                   sending the upload request.
 
     :type validate_identifier: bool
-    :param validate_identifier: (optional) Set to True to validate the identifier before 
+    :param validate_identifier: (optional) Set to True to validate the identifier before
                                 uploading the file.
 
     :param \*\*kwargs: Optional arguments that ``get_item`` takes.

--- a/internetarchive/cli/ia_upload.py
+++ b/internetarchive/cli/ia_upload.py
@@ -125,6 +125,21 @@ def _upload_files(item, files, upload_kwargs, prev_identifier=None, archive_sess
     return responses
 
 
+def _validate_identifier(identifier):
+    if not identifier:
+        print('error: no identifier column on spreadsheet!')
+        sys.exit(1)
+    try:
+        validate_ia_identifier(identifier)
+    except AssertionError:
+        print('error: identifier "{}" is invalid. '.format(identifier) +
+            '<identifier> should be between 3 and 80 characters in length, and '
+            'can only contain alphanumeric characters, periods ".", '
+            'underscores "_", or dashes "-". However, <identifier> cannot begin '
+            'with periods, underscores, or dashes.')
+        sys.exit(1)
+
+
 def main(argv, session):
     if six.PY2:
         args = docopt(__doc__.encode('utf-8'), argv=argv)
@@ -262,18 +277,7 @@ def main(argv, session):
                 upload_kwargs_copy = deepcopy(upload_kwargs)
                 local_file = row['file']
                 identifier = row.get('item', row.get('identifier'))
-                if not identifier:
-                    print('error: no identifier column on spreadsheet!')
-                    sys.exit(1)
-                try:
-                    validate_ia_identifier(identifier)
-                except AssertionError:
-                    print('error: identifier "{}" is invalid. '.format(identifier) +
-                        '<identifier> should be between 3 and 80 characters in length, and '
-                        'can only contain alphanumeric characters, periods ".", '
-                        'underscores "_", or dashes "-". However, <identifier> cannot begin '
-                        'with periods, underscores, or dashes.')
-                    sys.exit(1)
+                _validate_identifier(identifier)
                 del row['file']
                 if 'identifier' in row:
                     del row['identifier']

--- a/internetarchive/cli/ia_upload.py
+++ b/internetarchive/cli/ia_upload.py
@@ -54,7 +54,7 @@ options:
     --status-check                       Check if S3 is accepting requests to the given
                                          item.
     --no-collection-check                Skip collection exists check [default: False].
-    --validate-identifier                Validate the identifier before uploading the files 
+    --validate-identifier                Validate the identifier before uploading the files
                                          [default: False].
     -o, --open-after-upload              Open the details page for an item after upload
                                          [default: False].
@@ -140,7 +140,7 @@ def main(argv, session):
     # Validate args.
     s = Schema({
         str: Use(bool),
-        '<identifier>': Or(None, And(str, 
+        '<identifier>': Or(None, And(str,
             lambda id: not args['--validate-identifier'] or validate_s3_identifier(id),
             error=('<identifier> should be between 3 and 80 characters in length, and '
                    'can only contain alphanumeric characters, periods ".", '

--- a/internetarchive/cli/ia_upload.py
+++ b/internetarchive/cli/ia_upload.py
@@ -269,6 +269,9 @@ def main(argv, session):
                 upload_kwargs_copy = deepcopy(upload_kwargs)
                 local_file = row['file']
                 identifier = row.get('item', row.get('identifier'))
+                if not identifier:
+                    print('error: no identifier column on spreadsheet!')
+                    sys.exit(1)
                 del row['file']
                 if 'identifier' in row:
                     del row['identifier']

--- a/internetarchive/cli/ia_upload.py
+++ b/internetarchive/cli/ia_upload.py
@@ -265,6 +265,15 @@ def main(argv, session):
                 if not identifier:
                     print('error: no identifier column on spreadsheet!')
                     sys.exit(1)
+                try:
+                    validate_ia_identifier(identifier)
+                except:
+                    print('error: identifier "{}" is invalid. '.format(identifier) +
+                        '<identifier> should be between 3 and 80 characters in length, and '
+                        'can only contain alphanumeric characters, periods ".", '
+                        'underscores "_", or dashes "-". However, <identifier> cannot begin '
+                        'with periods, underscores, or dashes.')
+                    sys.exit(1)
                 del row['file']
                 if 'identifier' in row:
                     del row['identifier']

--- a/internetarchive/cli/ia_upload.py
+++ b/internetarchive/cli/ia_upload.py
@@ -54,8 +54,6 @@ options:
     --status-check                       Check if S3 is accepting requests to the given
                                          item.
     --no-collection-check                Skip collection exists check [default: False].
-    --validate-identifier                Validate the identifier before uploading the files
-                                         [default: False].
     -o, --open-after-upload              Open the details page for an item after upload
                                          [default: False].
 
@@ -140,8 +138,7 @@ def main(argv, session):
     # Validate args.
     s = Schema({
         str: Use(bool),
-        '<identifier>': Or(None, And(str,
-            lambda id: not args['--validate-identifier'] or validate_s3_identifier(id),
+        '<identifier>': Or(None, And(str, validate_s3_identifier,
             error=('<identifier> should be between 3 and 80 characters in length, and '
                    'can only contain alphanumeric characters, periods ".", '
                    'underscores "_", or dashes "-". However, <identifier> cannot begin '
@@ -230,7 +227,7 @@ def main(argv, session):
         retries=args['--retries'],
         retries_sleep=args['--sleep'],
         delete=args['--delete'],
-        validate_identifier=args['--validate-identifier']
+        validate_identifier=True
     )
 
     # Upload files.

--- a/internetarchive/cli/ia_upload.py
+++ b/internetarchive/cli/ia_upload.py
@@ -267,7 +267,7 @@ def main(argv, session):
                     sys.exit(1)
                 try:
                     validate_ia_identifier(identifier)
-                except:
+                except AssertionError:
                     print('error: identifier "{}" is invalid. '.format(identifier) +
                         '<identifier> should be between 3 and 80 characters in length, and '
                         'can only contain alphanumeric characters, periods ".", '

--- a/internetarchive/item.py
+++ b/internetarchive/item.py
@@ -912,7 +912,7 @@ class Item(BaseItem):
                       exit without sending the upload request.
 
         :type validate_identifier: bool
-        :param validate_identifier: (optional) Set to True to validate the identifier before 
+        :param validate_identifier: (optional) Set to True to validate the identifier before
                                     uploading the file.
 
         Usage::

--- a/internetarchive/item.py
+++ b/internetarchive/item.py
@@ -53,7 +53,7 @@ from internetarchive.utils import IdentifierListAsItems, get_md5, chunk_generato
 from internetarchive.files import File
 from internetarchive.iarequest import MetadataRequest, S3Request
 from internetarchive.auth import S3Auth
-from internetarchive.utils import get_s3_xml_text, get_file_size, is_dir
+from internetarchive.utils import get_s3_xml_text, get_file_size, is_dir, validate_s3_identifier
 
 log = getLogger(__name__)
 
@@ -859,6 +859,7 @@ class Item(BaseItem):
                     retries=None,
                     retries_sleep=None,
                     debug=None,
+                    validate_identifier=None,
                     request_kwargs=None):
         """Upload a single file to an item. The item will be created
         if it does not exist.
@@ -910,6 +911,10 @@ class Item(BaseItem):
         :param debug: (optional) Set to True to print headers to stdout, and
                       exit without sending the upload request.
 
+        :type validate_identifier: bool
+        :param validate_identifier: (optional) Set to True to validate the identifier before 
+                                    uploading the file.
+
         Usage::
 
             >>> import internetarchive
@@ -933,6 +938,7 @@ class Item(BaseItem):
         retries = 0 if retries is None else retries
         retries_sleep = 30 if retries_sleep is None else retries_sleep
         debug = False if debug is None else debug
+        validate_identifier = False if validate_identifier is None else validate_identifier
         request_kwargs = {} if request_kwargs is None else request_kwargs
         if 'timeout' not in request_kwargs:
             request_kwargs['timeout'] = 120
@@ -959,6 +965,8 @@ class Item(BaseItem):
             _headers['x-archive-size-hint'] = str(size)
 
         # Build IA-S3 URL.
+        if validate_identifier:
+            validate_s3_identifier(self.identifier)
         key = norm_filepath(filename).split('/')[-1] if key is None else key
         base_url = '{0.session.protocol}//s3.us.archive.org/{0.identifier}'.format(self)
         url = '{0}/{1}'.format(
@@ -1112,6 +1120,7 @@ class Item(BaseItem):
                retries=None,
                retries_sleep=None,
                debug=None,
+               validate_identifier=None,
                request_kwargs=None):
         """Upload files to an item. The item will be created if it
         does not exist.
@@ -1218,6 +1227,7 @@ class Item(BaseItem):
                                             retries=retries,
                                             retries_sleep=retries_sleep,
                                             debug=debug,
+                                            validate_identifier=validate_identifier,
                                             request_kwargs=request_kwargs)
                     responses.append(resp)
             else:
@@ -1251,6 +1261,7 @@ class Item(BaseItem):
                                         retries=retries,
                                         retries_sleep=retries_sleep,
                                         debug=debug,
+                                        validate_identifier=validate_identifier,
                                         request_kwargs=request_kwargs)
                 responses.append(resp)
         return responses

--- a/internetarchive/utils.py
+++ b/internetarchive/utils.py
@@ -56,6 +56,31 @@ def map2x(func, *iterables):
     return starmap(func, zipped)
 
 
+class InvalidIdentifierException(Exception):
+    pass
+
+
+def validate_s3_identifier(string):
+    legal_chars = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789._-'
+    # periods, underscores, and dashes are legal, but may not be the first
+    # character!
+    if any(string.startswith(c) is True for c in ['.', '_', '-']):
+        raise InvalidIdentifierException('Identifier cannot begin with periods ".", underscores '
+                                        '"_", or dashes "-".')
+
+    if len(string) > 100 or len(string) < 3:
+        raise InvalidIdentifierException('Identifier should be between 3 and 80 characters in '
+                                        'length.')
+
+    if any(c not in legal_chars for c in string):
+        raise InvalidIdentifierException('Identifier can only contain alphanumeric characters, '
+                                        'periods ".", underscores "_", or dashes "-". However, '
+                                        'identifier cannot begin with periods, underscores, or '
+                                        'dashes.')
+
+    return True
+
+
 def validate_ia_identifier(string):
     legal_chars = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789._-'
     # periods, underscores, and dashes are legal, but may not be the first

--- a/internetarchive/utils.py
+++ b/internetarchive/utils.py
@@ -81,16 +81,6 @@ def validate_s3_identifier(string):
     return True
 
 
-def validate_ia_identifier(string):
-    legal_chars = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789._-'
-    # periods, underscores, and dashes are legal, but may not be the first
-    # character!
-    assert all(string.startswith(c) is False for c in ['.', '_', '-'])
-    assert 100 >= len(string) >= 3
-    assert all(c in legal_chars for c in string)
-    return True
-
-
 def needs_quote(s):
     try:
         s.encode('ascii')

--- a/tests/cli/test_ia_upload.py
+++ b/tests/cli/test_ia_upload.py
@@ -28,9 +28,9 @@ def test_ia_upload_validate_identifier(capsys, caplog):
     with open('test.txt', 'w') as fh:
         fh.write('foo')
 
-    ia_call(['ia', '--log', 'upload', 'føø', 'test.txt', '--validate-identifier'], 
+    ia_call(['ia', '--log', 'upload', 'føø', 'test.txt', '--validate-identifier'],
             expected_exit_code=1)
-            
+
     out, err = capsys.readouterr()
     assert ('<identifier> should be between 3 and 80 characters in length, and '
             'can only contain alphanumeric characters, periods ".", '

--- a/tests/cli/test_ia_upload.py
+++ b/tests/cli/test_ia_upload.py
@@ -24,6 +24,31 @@ def test_ia_upload(tmpdir_ch, caplog):
             'test.txt'.format(PROTOCOL)) in caplog.text
 
 
+def test_ia_upload_validate_identifier(capsys, caplog):
+    with open('test.txt', 'w') as fh:
+        fh.write('foo')
+
+    ia_call(['ia', '--log', 'upload', 'føø', 'test.txt', '--validate-identifier'], 
+            expected_exit_code=1)
+            
+    out, err = capsys.readouterr()
+    assert ('<identifier> should be between 3 and 80 characters in length, and '
+            'can only contain alphanumeric characters, periods ".", '
+            'underscores "_", or dashes "-". However, <identifier> cannot begin '
+            'with periods, underscores, or dashes.') in err
+
+    # Test --validate-identifier flag with valid identifier
+    with IaRequestsMock() as rsps:
+        rsps.add_metadata_mock('nasa')
+        rsps.add(responses.PUT, '{0}//s3.us.archive.org/nasa/test.txt'.format(PROTOCOL),
+                 body='',
+                 content_type='text/plain')
+        ia_call(['ia', '--log', 'upload', 'nasa', 'test.txt', '--validate-identifier'])
+
+    assert ('uploaded test.txt to {0}//s3.us.archive.org/nasa/'
+            'test.txt'.format(PROTOCOL)) in caplog.text
+
+
 def test_ia_upload_status_check(capsys):
     with IaRequestsMock() as rsps:
         rsps.add(responses.GET, '{0}//s3.us.archive.org'.format(PROTOCOL),

--- a/tests/cli/test_ia_upload.py
+++ b/tests/cli/test_ia_upload.py
@@ -24,11 +24,11 @@ def test_ia_upload(tmpdir_ch, caplog):
             'test.txt'.format(PROTOCOL)) in caplog.text
 
 
-def test_ia_upload_validate_identifier(capsys, caplog):
+def test_ia_upload_invalid_identifier(capsys, caplog):
     with open('test.txt', 'w') as fh:
         fh.write('foo')
 
-    ia_call(['ia', '--log', 'upload', 'føø', 'test.txt', '--validate-identifier'],
+    ia_call(['ia', '--log', 'upload', 'føø', 'test.txt'],
             expected_exit_code=1)
 
     out, err = capsys.readouterr()
@@ -36,17 +36,6 @@ def test_ia_upload_validate_identifier(capsys, caplog):
             'can only contain alphanumeric characters, periods ".", '
             'underscores "_", or dashes "-". However, <identifier> cannot begin '
             'with periods, underscores, or dashes.') in err
-
-    # Test --validate-identifier flag with valid identifier
-    with IaRequestsMock() as rsps:
-        rsps.add_metadata_mock('nasa')
-        rsps.add(responses.PUT, '{0}//s3.us.archive.org/nasa/test.txt'.format(PROTOCOL),
-                 body='',
-                 content_type='text/plain')
-        ia_call(['ia', '--log', 'upload', 'nasa', 'test.txt', '--validate-identifier'])
-
-    assert ('uploaded test.txt to {0}//s3.us.archive.org/nasa/'
-            'test.txt'.format(PROTOCOL)) in caplog.text
 
 
 def test_ia_upload_status_check(capsys):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
 import json

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -10,6 +10,8 @@ from requests.packages import urllib3
 
 from internetarchive import get_session, get_item, get_files, modify_metadata, upload, \
     download, search_items
+
+from internetarchive.utils import InvalidIdentifierException
 from tests.conftest import NASA_METADATA_PATH, PROTOCOL, IaRequestsMock, \
     load_test_data_file, load_file
 
@@ -223,6 +225,37 @@ def test_upload():
             del headers['user-agent']
             assert headers == expected_s3_headers
             assert req.url == '{0}//s3.us.archive.org/nasa/nasa.json'.format(PROTOCOL)
+
+
+def test_upload_validate_identifier():
+    try:
+        upload('føø', NASA_METADATA_PATH, 
+              access_key='test_access',
+              secret_key='test_secret',
+              validate_identifier=True)
+        assert False
+    except Exception as exc:
+        assert isinstance(exc, InvalidIdentifierException)
+
+    expected_s3_headers = {
+        'content-length': '7557',
+        'x-archive-queue-derive': '1',
+        'x-archive-meta00-scanner': 'uri(Internet%20Archive%20Python%20library',
+        'x-archive-size-hint': '7557',
+        'x-archive-auto-make-bucket': '1',
+        'authorization': 'LOW test_access:test_secret',
+    }
+    with IaRequestsMock(assert_all_requests_are_fired=False) as rsps:
+        rsps.add(responses.PUT, re.compile(r'.*s3.us.archive.org/.*'),
+                 adding_headers=expected_s3_headers)
+        rsps.add_metadata_mock('nasa')
+        rsps.add(responses.GET, '{0}//archive.org/metadata/nasa'.format(PROTOCOL),
+                 body='{}')
+        upload('nasa', NASA_METADATA_PATH,
+              access_key='test_access',
+              secret_key='test_secret',
+              validate_identifier=True)
+        assert True
 
 
 def test_download(tmpdir):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -229,7 +229,7 @@ def test_upload():
 
 def test_upload_validate_identifier():
     try:
-        upload('føø', NASA_METADATA_PATH, 
+        upload('føø', NASA_METADATA_PATH,
               access_key='test_access',
               secret_key='test_secret',
               validate_identifier=True)

--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -2,7 +2,7 @@
 from __future__ import unicode_literals
 
 from internetarchive.api import get_item
-from internetarchive.utils import norm_filepath
+from internetarchive.utils import norm_filepath, InvalidIdentifierException
 from tests.conftest import PROTOCOL, IaRequestsMock, load_file, \
     NASA_METADATA_PATH, load_test_data_file
 
@@ -295,6 +295,31 @@ def test_upload(nasa_item):
             del headers['user-agent']
             assert headers == EXPECTED_S3_HEADERS
             assert request.url == '{0}//s3.us.archive.org/nasa/nasa.json'.format(PROTOCOL)
+
+
+def test_upload_validate_identifier(session):
+    item = session.get_item('føø')
+    with IaRequestsMock(assert_all_requests_are_fired=False) as rsps:
+        rsps.add(responses.PUT, S3_URL_RE,
+                 adding_headers=EXPECTED_S3_HEADERS)
+        try:
+            item.upload(NASA_METADATA_PATH, 
+                        access_key='a',
+                        secret_key='b',
+                        validate_identifier=True)
+            assert False
+        except Exception as exc:
+            assert isinstance(exc, InvalidIdentifierException)
+
+    valid_item = session.get_item('foo')
+    with IaRequestsMock(assert_all_requests_are_fired=False) as rsps:
+        rsps.add(responses.PUT, S3_URL_RE,
+                 adding_headers=EXPECTED_S3_HEADERS)
+        valid_item.upload(NASA_METADATA_PATH,
+                        access_key='a',
+                        secret_key='b',
+                        validate_identifier=True)
+        assert True
 
 
 def test_upload_secure_session():

--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -303,7 +303,7 @@ def test_upload_validate_identifier(session):
         rsps.add(responses.PUT, S3_URL_RE,
                  adding_headers=EXPECTED_S3_HEADERS)
         try:
-            item.upload(NASA_METADATA_PATH, 
+            item.upload(NASA_METADATA_PATH,
                         access_key='a',
                         secret_key='b',
                         validate_identifier=True)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -23,13 +23,21 @@ def test_needs_quote():
     assert not internetarchive.utils.needs_quote(string.ascii_letters + string.digits)
 
 
-def test_validate_ia_identifier():
-    valid = internetarchive.utils.validate_ia_identifier('valid-Id-123-_foo')
+def test_validate_s3_identifier():
+    id1 = 'valid-Id-123-_foo'
+    id2 = '!invalid-Id-123-_foo'
+    id3 = 'invalid-Id-123-_foo+bar'
+    id4 = 'invalid-Id-123-_føø'
+    id5 = 'i'
+
+    valid = internetarchive.utils.validate_s3_identifier(id1)
     assert valid
-    try:
-        internetarchive.utils.validate_ia_identifier('!invalid-Id-123-_foo')
-    except Exception as exc:
-        assert isinstance(exc, AssertionError)
+
+    for invalid_id in [id2, id3, id4, id5]:
+        try:
+            internetarchive.utils.validate_s3_identifier(invalid_id)
+        except Exception as exc:
+            assert isinstance(exc, internetarchive.utils.InvalidIdentifierException)
 
 
 def test_get_md5():


### PR DESCRIPTION
If a spreadsheet for bulk upload includes an invalid identifier, the CLI would upload the entire file before reporting the error, and the entire file would have to be uploaded again after fixing the identifier.

This was previously noted in #203.

The CLI will now validate the identifier on the client side before uploading, and will terminate the program if an invalid identifier is encountered.