### PR TITLE
feat: don't retry if spam detected

### DIFF
--- a/internetarchive/item.py
+++ b/internetarchive/item.py
@@ -1059,6 +1059,9 @@ class Item(BaseItem):
                                                  stream=True,
                                                  **request_kwargs)
                     if (response.status_code == 503) and (retries > 0):
+                        if b'appears to be spam' in response.content:
+                            log.info('detected as spam, upload failed')
+                            break
                         log.info(error_msg)
                         if verbose:
                             print(' warning: {0}'.format(error_msg), file=sys.stderr)


### PR DESCRIPTION
Fixes #298 . I know it's already closed as an issue for archive.org, but the problem is still happening, and this change helps.

Occasionally a mirrored item can be marked as spam. In this case there's not much point retrying as it'll be marked as spam again. This changes ia to abort early if that happens.

I didn't change `get_s3_xml_text` to include the RequestId, so the error is just:
```
 error uploading cRRrauRtugc.description: Please reduce your request rate. - Your upload of youtube-cRRrauRtugc from username ***@gmail.com appears to be spam. If you believe this is a mistake, contact info@archive.org and include this entire message in your email.
```

If the RequestId helps (or if "this entire message" should be something different) I can look at adding it.