### PR TITLE
Simplify the logic of identifier_available, making it more idiomatic and readable.

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -12,6 +12,7 @@ Contributors
 ------------
 
 - Bryce Drennan <internetarchive@brycedrennan.com>
+- Max Zettlmeißl <max@zettlmeissl.de>
 
 Patches and Suggestions
 -----------------------

--- a/internetarchive/item.py
+++ b/internetarchive/item.py
@@ -32,7 +32,6 @@ from fnmatch import fnmatch
 from logging import getLogger
 from time import sleep
 import math
-from xml.dom.minidom import parseString
 from xml.parsers.expat import ExpatError
 
 try:
@@ -230,11 +229,9 @@ class Item(BaseItem):
         """
         url = '{}//{}/services/check_identifier.php'.format(self.session.protocol,
                                                             self.session.host)
-        params = dict(identifier=self.identifier)
-        r = self.session.get(url, params=params)
-        p = parseString(r.text)
-        result = p.getElementsByTagName('result')[0]
-        availability = result.attributes['code'].value
+        params = dict(output='json', identifier=self.identifier)
+        response = self.session.get(url, params=params)
+        availability = response.json()['code']
         return availability == 'available'
 
     def get_task_summary(self, params=None, request_kwargs=None):

--- a/internetarchive/item.py
+++ b/internetarchive/item.py
@@ -235,10 +235,7 @@ class Item(BaseItem):
         p = parseString(r.text)
         result = p.getElementsByTagName('result')[0]
         available = result.attributes['code'].value
-        if available == 'not_available':
-            return False
-        else:
-            return True
+        return available == 'available'
 
     def get_task_summary(self, params=None, request_kwargs=None):
         """Get a summary of the item's pending tasks.

--- a/internetarchive/item.py
+++ b/internetarchive/item.py
@@ -234,8 +234,8 @@ class Item(BaseItem):
         r = self.session.get(url, params=params)
         p = parseString(r.text)
         result = p.getElementsByTagName('result')[0]
-        available = result.attributes['code'].value
-        return available == 'available'
+        availability = result.attributes['code'].value
+        return availability == 'available'
 
     def get_task_summary(self, params=None, request_kwargs=None):
         """Get a summary of the item's pending tasks.

--- a/internetarchive/item.py
+++ b/internetarchive/item.py
@@ -2,7 +2,7 @@
 #
 # The internetarchive module is a Python/CLI interface to Archive.org.
 #
-# Copyright (C) 2012-2019 Internet Archive
+# Copyright (C) 2012-2021 Internet Archive
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -21,7 +21,7 @@
 internetarchive.item
 ~~~~~~~~~~~~~~~~~~~~
 
-:copyright: (C) 2012-2019 by Internet Archive.
+:copyright: (C) 2012-2021 by Internet Archive.
 :license: AGPL 3, see LICENSE for more details.
 """
 from __future__ import absolute_import, unicode_literals, print_function


### PR DESCRIPTION
When looking how you handled to check for available identifiers, I came across this rather unidiomatic statement which could be simplified by reversing the unnecessary negation, since the check_identifier.php returns `<result type="success" code="available">` ([example](https://archive.org/services/check_identifier.php?identifier=quux)) if the identifier is available and the previously relied upon `<result type="success" code="not_available">` ([example](https://archive.org/services/check_identifier.php?identifier=foobar)) if it is unavailable.

It should also correspond better with the actual availability, in case the codes ever get expanded in the future and currently maps more directly to the method's name.

By requesting the [seemingly more modern JSON](https://archive.org/help/json.php) instead of XML data, the somewhat hairy availability code extraction could be further simplified from a DOM tree traversal into a dictionary lookup.
