### PR TITLE
Fix return type for modify_metadata

### DIFF
--- a/internetarchive/item.py
+++ b/internetarchive/item.py
@@ -781,7 +781,7 @@ class Item(BaseItem):
             >>> md = dict(new_key='new_value', foo=['bar', 'bar2'])
             >>> item.modify_metadata(md)
 
-        :rtype: dict
+        :rtype: Response
         :returns: A dictionary containing the status_code and response
                   returned from the Metadata API.
         """


### PR DESCRIPTION
The correct rtype is requests.Response, not dict