### PR TITLE
Wrap long lines according to PEP8.

### DIFF
--- a/internetarchive/cli/__init__.py
+++ b/internetarchive/cli/__init__.py
@@ -21,7 +21,7 @@
 internetarchive.cli
 ~~~~~~~~~~~~~~~~~~~
 
-:copyright: (C) 2012-2019 by Internet Archive.
+:copyright: (C) 2012-2016, 2021 by Internet Archive.
 :license: AGPL 3, see LICENSE for more details.
 """
 from internetarchive.cli import (ia, ia_configure, ia_delete, ia_download,

--- a/internetarchive/cli/__init__.py
+++ b/internetarchive/cli/__init__.py
@@ -2,7 +2,7 @@
 #
 # The internetarchive module is a Python/CLI interface to Archive.org.
 #
-# Copyright (C) 2012-2019 Internet Archive
+# Copyright (C) 2012-2016, 2021 Internet Archive
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -24,8 +24,9 @@ internetarchive.cli
 :copyright: (C) 2012-2019 by Internet Archive.
 :license: AGPL 3, see LICENSE for more details.
 """
-from internetarchive.cli import ia, ia_configure, ia_delete, ia_download, ia_list, \
-    ia_metadata, ia_search, ia_tasks, ia_upload, argparser
+from internetarchive.cli import (ia, ia_configure, ia_delete, ia_download,
+                                 ia_list, ia_metadata, ia_search, ia_tasks,
+                                 ia_upload, argparser)
 
 
 __all__ = [

--- a/internetarchive/cli/ia_metadata.py
+++ b/internetarchive/cli/ia_metadata.py
@@ -2,7 +2,7 @@
 #
 # The internetarchive module is a Python/CLI interface to Archive.org.
 #
-# Copyright (C) 2012-2019 Internet Archive
+# Copyright (C) 2012-2021 Internet Archive
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -216,8 +216,8 @@ def main(argv, session):
                     sys.exit(1)
 
         # Modify metadata.
-        elif args['--modify'] or args['--append'] or args['--append-list'] \
-                or args['--remove']:
+        elif (args['--modify'] or args['--append'] or args['--append-list']
+              or args['--remove']):
             if args['--modify']:
                 metadata_args = args['--modify']
             elif args['--append']:

--- a/internetarchive/cli/ia_tasks.py
+++ b/internetarchive/cli/ia_tasks.py
@@ -2,7 +2,7 @@
 #
 # The internetarchive module is a Python/CLI interface to Archive.org.
 #
-# Copyright (C) 2012-2019 Internet Archive
+# Copyright (C) 2012-2021 Internet Archive
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -132,8 +132,8 @@ def main(argv, session):
         'submittime',
     ]
 
-    if not args['<identifier>'] \
-            and not params.get('task_id'):
+    if not (args['<identifier>']
+            or params.get('task_id')):
         _params = dict(catalog=1, history=0)
         _params.update(params)
         params = _params

--- a/internetarchive/iarequest.py
+++ b/internetarchive/iarequest.py
@@ -150,8 +150,8 @@ class S3PreparedRequest(requests.models.PreparedRequest):
                     meta_value = json.dumps(meta_value)
                 # Convert the metadata value into a list if it is not already
                 # iterable.
-                if (isinstance(meta_value, six.string_types) or
-                        not hasattr(meta_value, '__iter__')):
+                if (isinstance(meta_value, six.string_types)
+                        or not hasattr(meta_value, '__iter__')):
                     meta_value = [meta_value]
                 # Convert metadata items into HTTP headers and add to
                 # ``headers`` dict.
@@ -258,10 +258,10 @@ class MetadataPreparedRequest(requests.models.PreparedRequest):
 
         # Write to many targets
         if (isinstance(metadata, list)
-            or any('/' in k for k in metadata)
-            or all(isinstance(k, dict) for k in metadata.values())):
-
+                or any('/' in k for k in metadata)
+                or all(isinstance(k, dict) for k in metadata.values())):
             changes = list()
+
             if any(not k for k in metadata):
                 raise ValueError('Invalid metadata provided, '
                                  'check your input and try again')

--- a/internetarchive/iarequest.py
+++ b/internetarchive/iarequest.py
@@ -2,7 +2,7 @@
 #
 # The internetarchive module is a Python/CLI interface to Archive.org.
 #
-# Copyright (C) 2012-2019 Internet Archive
+# Copyright (C) 2012-2021 Internet Archive
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -21,7 +21,7 @@
 internetarchive.iarequest
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-:copyright: (C) 2012-2019 by Internet Archive.
+:copyright: (C) 2012-2021 by Internet Archive.
 :license: AGPL 3, see LICENSE for more details.
 """
 from __future__ import absolute_import
@@ -257,11 +257,11 @@ class MetadataPreparedRequest(requests.models.PreparedRequest):
             source_metadata = r.json()
 
         # Write to many targets
-        if isinstance(metadata, list) \
-                or any('/' in k for k in metadata) \
-                or all(isinstance(k, dict) for k in metadata.values()):
-            changes = list()
+        if (isinstance(metadata, list)
+            or any('/' in k for k in metadata)
+            or all(isinstance(k, dict) for k in metadata.values())):
 
+            changes = list()
             if any(not k for k in metadata):
                 raise ValueError('Invalid metadata provided, '
                                  'check your input and try again')

--- a/internetarchive/item.py
+++ b/internetarchive/item.py
@@ -47,12 +47,15 @@ from requests import Response
 from tqdm import tqdm
 from requests.exceptions import HTTPError
 
-from internetarchive.utils import IdentifierListAsItems, get_md5, chunk_generator, \
-    IterableToFileAdapter, iter_directory, recursive_file_count, norm_filepath
+from internetarchive.utils import (IdentifierListAsItems, get_md5,
+                                   chunk_generator, IterableToFileAdapter,
+                                   iter_directory, recursive_file_count,
+                                   norm_filepath)
 from internetarchive.files import File
 from internetarchive.iarequest import MetadataRequest, S3Request
 from internetarchive.auth import S3Auth
-from internetarchive.utils import get_s3_xml_text, get_file_size, is_dir, validate_s3_identifier
+from internetarchive.utils import (get_s3_xml_text, get_file_size, is_dir,
+                                   validate_s3_identifier)
 
 log = getLogger(__name__)
 
@@ -106,11 +109,11 @@ class BaseItem(object):
         self.collection = IdentifierListAsItems(mc, self.session)
 
     def __eq__(self, other):
-        return self.item_metadata == other.item_metadata or \
-            (self.item_metadata.keys() == other.item_metadata.keys() and
-             all(self.item_metadata[x] == other.item_metadata[x]
-                 for x in self.item_metadata
-                 if x not in self.EXCLUDED_ITEM_METADATA_KEYS))
+        return (self.item_metadata == other.item_metadata
+                or (self.item_metadata.keys() == other.item_metadata.keys()
+                    and all(self.item_metadata[x] == other.item_metadata[x]
+                            for x in self.item_metadata
+                            if x not in self.EXCLUDED_ITEM_METADATA_KEYS)))
 
     def __le__(self, other):
         return self.identifier <= other.identifier
@@ -181,8 +184,8 @@ class Item(BaseItem):
 
         if self.metadata.get('title'):
             # A copyable link to the item, in MediaWiki format
-            self.wikilink = '* [{0.urls.details} {0.identifier}] ' \
-                            '-- {0.metadata[title]}'.format(self)
+            self.wikilink = ('* [{0.urls.details} {0.identifier}] '
+                             '-- {0.metadata[title]}').format(self)
 
     class URLs:
         def __init__(self, itm_obj):
@@ -211,8 +214,8 @@ class Item(BaseItem):
             self._paths.append(path)
 
         def __str__(self):
-            return "URLs ({1}) for {0.identifier}" \
-                   .format(self._itm_obj, ', '.join(self._paths))
+            return ("URLs ({1}) for {0.identifier}"
+                    .format(self._itm_obj, ', '.join(self._paths)))
 
     def refresh(self, item_metadata=None, **kwargs):
         if not item_metadata:
@@ -1179,8 +1182,8 @@ class Item(BaseItem):
                     file_metadata = f.copy()
                     del file_metadata['name']
                     f = f['name']
-            if (isinstance(f, string_types) and is_dir(f)) \
-                    or (isinstance(f, tuple) and is_dir(f[-1])):
+            if ((isinstance(f, string_types) and is_dir(f))
+                or (isinstance(f, tuple) and is_dir(f[-1]))):
                 if isinstance(f, tuple):
                     remote_dir_name = f[0].strip('/')
                     f = f[-1]

--- a/internetarchive/item.py
+++ b/internetarchive/item.py
@@ -1183,7 +1183,7 @@ class Item(BaseItem):
                     del file_metadata['name']
                     f = f['name']
             if ((isinstance(f, string_types) and is_dir(f))
-                or (isinstance(f, tuple) and is_dir(f[-1]))):
+                    or (isinstance(f, tuple) and is_dir(f[-1]))):
                 if isinstance(f, tuple):
                     remote_dir_name = f[0].strip('/')
                     f = f[-1]

--- a/internetarchive/utils.py
+++ b/internetarchive/utils.py
@@ -2,7 +2,7 @@
 #
 # The internetarchive module is a Python/CLI interface to Archive.org.
 #
-# Copyright (C) 2012-2019 Internet Archive
+# Copyright (C) 2012-2021 Internet Archive
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -23,7 +23,7 @@ internetarchive.utils
 
 This module provides utility functions for the internetarchive library.
 
-:copyright: (C) 2012-2019 by Internet Archive.
+:copyright: (C) 2012-2021 by Internet Archive.
 :license: AGPL 3, see LICENSE for more details.
 """
 import hashlib
@@ -150,10 +150,9 @@ class IdentifierListAsItems(object):
     """
 
     def __init__(self, id_list_or_single_id, session):
-        self.ids = id_list_or_single_id \
-            if isinstance(id_list_or_single_id, list) \
-            else [id_list_or_single_id]
-
+        self.ids = (id_list_or_single_id
+                    if isinstance(id_list_or_single_id, list)
+                    else [id_list_or_single_id])
         self._items = [None] * len(self.ids)
         self.session = session
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 universal = 1
 
 [flake8]
-ignore = E128,E722,F401,F841,W504,W605
+ignore = E128,E722,F401,F841,W503,W605
 max-complexity = 34
 max-line-length = 102
 per-file-ignores =

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -9,12 +9,12 @@ import responses
 import six
 from requests.packages import urllib3
 
-from internetarchive import get_session, get_item, get_files, modify_metadata, upload, \
-    download, search_items
+from internetarchive import (get_session, get_item, get_files, modify_metadata,
+                             upload, download, search_items)
 
 from internetarchive.utils import InvalidIdentifierException
-from tests.conftest import NASA_METADATA_PATH, PROTOCOL, IaRequestsMock, \
-    load_test_data_file, load_file
+from tests.conftest import (NASA_METADATA_PATH, PROTOCOL, IaRequestsMock,
+                            load_test_data_file, load_file)
 
 PY3 = six.PY3
 

--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -3,8 +3,8 @@ from __future__ import unicode_literals
 
 from internetarchive.api import get_item
 from internetarchive.utils import norm_filepath, InvalidIdentifierException
-from tests.conftest import PROTOCOL, IaRequestsMock, load_file, \
-    NASA_METADATA_PATH, load_test_data_file
+from tests.conftest import (PROTOCOL, IaRequestsMock, load_file,
+                            NASA_METADATA_PATH, load_test_data_file)
 
 try:
     import ujson as json


### PR DESCRIPTION
Change the line wrapping via backslashes to using Python's implied line continuation inside parentheses, as recommended by PEP8.

Additionally adjust the copyright dates of all files which I touched and correct the copyright date for `internetarchive/cli/__init__.py` to include only years in which potentially copyrightable changes occurred.
(As per [How to use GNU licenses for your own software](https://www.gnu.org/licenses/gpl-howto.en.html), section "The copyright notice".)

When I touch a file, I generally check its history and adjust the years accordingly.

During the wrapping changes I also saw that one of the expressions could be simplified using De Morgan's laws, so I simplified it and made that file's changes into an extra commit.
