### PR TITLE
Falsey values in (targeted?) metadata changes

### DIFF
--- a/internetarchive/utils.py
+++ b/internetarchive/utils.py
@@ -336,7 +336,7 @@ def remove_none(obj):
             return lst
     elif isinstance(obj, dict):
         return type(obj)((remove_none(k), remove_none(v))
-                         for k, v in obj.items() if k is not None and v)
+                         for k, v in obj.items() if k is not None and v is not None)
     else:
         return obj
 


### PR DESCRIPTION
`and v` is what’s causing falsey values in metadata targets not to be dropped, but since I’m not sure why that condition would be there in the first place, I'm not sure if this would have other consequences...