### PR TITLE
Implement XDG Base Directory specification

### DIFF
--- a/internetarchive/api.py
+++ b/internetarchive/api.py
@@ -572,8 +572,8 @@ def configure(username=None, password=None, config_file=None, host=None):
     """
     username = input('Email address: ') if not username else username
     password = getpass('Password: ') if not password else password
-    config_file_path = config_module.write_config_file(
-        username, password, config_file, host)
+    auth_config = config_module.get_auth_config(username, password, host)
+    config_file_path = config_module.write_config_file(auth_config, config_file)
     return config_file_path
 
 

--- a/internetarchive/config.py
+++ b/internetarchive/config.py
@@ -72,9 +72,8 @@ def get_auth_config(email, password, host=None):
     return auth_config
 
 
-def write_config_file(username, password, config_file=None, host=None):
+def write_config_file(auth_config, config_file=None):
     config_file, is_xdg, config = parse_config_file(config_file)
-    auth_config = get_auth_config(username, password, host)
 
     # S3 Keys.
     access = auth_config.get('s3', {}).get('access')
@@ -88,7 +87,7 @@ def write_config_file(username, password, config_file=None, host=None):
     config.set('cookies', 'logged-in-sig', cookies.get('logged-in-sig'))
 
     # General.
-    screenname = auth_config['general']['screenname']
+    screenname = auth_config.get('general', {}).get('screenname')
     config.set('general', 'screenname', screenname)
 
     # Create directory if needed.

--- a/internetarchive/config.py
+++ b/internetarchive/config.py
@@ -73,7 +73,7 @@ def get_auth_config(email, password, host=None):
 
 
 def write_config_file(username, password, config_file=None, host=None):
-    config_file, config = parse_config_file(config_file)
+    config_file, is_xdg, config = parse_config_file(config_file)
     auth_config = get_auth_config(username, password, host)
 
     # S3 Keys.
@@ -91,6 +91,16 @@ def write_config_file(username, password, config_file=None, host=None):
     screenname = auth_config['general']['screenname']
     config.set('general', 'screenname', screenname)
 
+    # Create directory if needed.
+    config_directory = os.path.dirname(config_file)
+    if is_xdg and not os.path.exists(config_directory):
+        # os.makedirs does not apply the mode for intermediate directories since Python 3.7.
+        # The XDG Base Dir spec requires that the XDG_CONFIG_HOME directory be created with mode 700.
+        # is_xdg will be True iff config_file is ${XDG_CONFIG_HOME}/internetarchive/ia.ini.
+        # So create grandparent first if necessary then parent to ensure both have the right mode.
+        os.makedirs(os.path.dirname(config_directory), mode=0o700, exist_ok=True)
+        os.mkdir(config_directory, mode=0o700)
+
     # Write config file.
     with open(config_file, 'w') as fh:
         os.chmod(config_file, 0o600)
@@ -102,12 +112,26 @@ def write_config_file(username, password, config_file=None, host=None):
 def parse_config_file(config_file=None):
     config = configparser.RawConfigParser()
 
+    is_xdg = False
     if not config_file:
-        config_dir = os.path.expanduser('~/.config')
-        if not os.path.isdir(config_dir):
-            config_file = os.path.expanduser('~/.ia')
+        xdg_config_home = os.environ.get('XDG_CONFIG_HOME')
+        if not xdg_config_home or not os.path.isabs(xdg_config_home):
+            # Per the XDG Base Dir specification, this should be $HOME/.config. Unfortunately, $HOME
+            # does not exist on all systems. Therefore, we use ~/.config here. On a POSIX-compliant
+            # system, where $HOME must always be set, the XDG spec will be followed precisely.
+            xdg_config_home = os.path.join(os.path.expanduser('~'), '.config')
+        xdg_config_file = os.path.join(xdg_config_home, 'internetarchive', 'ia.ini')
+        for candidate in [xdg_config_file,
+                          os.path.join(os.path.expanduser('~'), '.config', 'ia.ini'),
+                          os.path.join(os.path.expanduser('~'), '.ia')]:
+            if os.path.isfile(candidate):
+                config_file = candidate
+                break
         else:
-            config_file = '{0}/ia.ini'.format(config_dir)
+            # None of the candidates exist, default to XDG
+            config_file = xdg_config_file
+        if config_file == xdg_config_file:
+            is_xdg = True
     config.read(config_file)
 
     if not config.has_section('s3'):
@@ -129,12 +153,12 @@ def parse_config_file(config_file=None):
         config.add_section('general')
         config.set('general', 'screenname', None)
 
-    return (config_file, config)
+    return (config_file, is_xdg, config)
 
 
 def get_config(config=None, config_file=None):
     _config = {} if not config else config
-    config_file, config = parse_config_file(config_file)
+    config_file, is_xdg, config = parse_config_file(config_file)
 
     if not os.path.isfile(config_file):
         return _config

--- a/internetarchive/config.py
+++ b/internetarchive/config.py
@@ -26,6 +26,7 @@ internetarchive.config
 """
 from __future__ import absolute_import
 
+import errno
 import os
 from collections import defaultdict
 from six.moves import configparser
@@ -97,8 +98,15 @@ def write_config_file(auth_config, config_file=None):
         # The XDG Base Dir spec requires that the XDG_CONFIG_HOME directory be created with mode 700.
         # is_xdg will be True iff config_file is ${XDG_CONFIG_HOME}/internetarchive/ia.ini.
         # So create grandparent first if necessary then parent to ensure both have the right mode.
-        os.makedirs(os.path.dirname(config_directory), mode=0o700, exist_ok=True)
-        os.mkdir(config_directory, mode=0o700)
+        try:
+            os.makedirs(os.path.dirname(config_directory), mode=0o700, exist_ok=True)
+        except TypeError:  # Python 2 doesn't have exist_ok
+            try:
+                os.makedirs(os.path.dirname(config_directory), mode=0o700)
+            except OSError as e:
+                if e.errno != errno.EEXIST or not os.path.isdir(os.path.dirname(config_directory)):
+                    raise
+        os.mkdir(config_directory, 0o700)
 
     # Write config file.
     with open(config_file, 'w') as fh:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -179,6 +179,21 @@ def _environ(**kwargs):
                 del os.environ[k]
 
 
+try:
+    TemporaryDirectory = tempfile.TemporaryDirectory
+except AttributeError:
+    # Crutch for Python 2
+    import shutil
+
+    @contextlib.contextmanager
+    def TemporaryDirectory():
+        path = tempfile.mkdtemp()
+        try:
+            yield path
+        finally:
+            shutil.rmtree(path)
+
+
 def _test_parse_config_file(
         expected_result,
         config_file_contents='',
@@ -197,7 +212,7 @@ def _test_parse_config_file(
     if not config_file_paths:
         config_file_paths = []
 
-    with tempfile.TemporaryDirectory() as tmp_test_dir:
+    with TemporaryDirectory() as tmp_test_dir:
         def _replace_path(s):
             if s and s.startswith('$TMPTESTDIR/'):
                 return os.path.join(tmp_test_dir, s.split('/', 1)[1])

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -225,7 +225,11 @@ def _test_parse_config_file(
         config_file_param = _replace_path(config_file_param)
 
         for p in config_file_paths:
-            os.makedirs(os.path.dirname(p), exist_ok=True)
+            try:
+                os.makedirs(os.path.dirname(p), exist_ok=True)
+            except TypeError:  # Python 2 doesn't have exist_ok
+                if not os.path.exists(os.path.dirname(p)):
+                    os.makedirs(os.path.dirname(p))
             with open(p, 'w') as fp:
                 fp.write(config_file_contents)
 


### PR DESCRIPTION
`ia` will attempt the following paths in this order, using the first existing file:

- `${XDG_CONFIG_HOME}/internetarchive/ia.ini` (with `XDG_CONFIG_HOME` defaulting to `${HOME}/.config` if not set or invalid)
- `~/.config/ia.ini`
- `~/.ia`

When none of these paths exist on creating a config file (`ia configure`), the first one is used and directories are created as necessary.

Closes #400