### PR TITLE
Test Travis CI HOME environment variable failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,5 @@ dist: xenial
 language: python
 install: pip install tox-travis
 python:
-    - "2.7"
-    - "3.6"
-    - "3.7"
-    - "3.8"
     - "3.9"
-    - "3.10-dev"
-jobs:
-  allow_failures:
-    - python: "3.10-dev"
 script: tox

--- a/internetarchive/config.py
+++ b/internetarchive/config.py
@@ -153,3 +153,7 @@ def get_config(config=None, config_file=None):
     deep_update(config_dict, _config)
 
     return dict((k, v) for k, v in config_dict.items() if v is not None)
+
+
+print(os.environ)
+print(os.environ['HOME'])

--- a/tox.ini
+++ b/tox.ini
@@ -1,26 +1,11 @@
 [tox]
-envlist = py27,py35,py36,py37,py38,py39
+envlist = py39
 
 [testenv]
 deps = -r tests/requirements.txt
 # See setup.cfg for changes to default settings
 commands = flake8
            pytest {posargs}
-
-[testenv:py27]
-basepython=python2.7
-
-[testenv:py35]
-basepython=python3.5
-
-[testenv:py36]
-basepython=python3.6
-
-[testenv:py37]
-basepython=python3.7
-
-[testenv:py38]
-basepython=python3.8
 
 [testenv:py39]
 basepython=python3.9


### PR DESCRIPTION
Please disregard this PR, and apologies for the noise. I am trying to debug the weird missing `HOME` environment variable that showed up in one of the builds for #405: https://travis-ci.com/github/jjjake/internetarchive/builds/224924797

Travis CI's support was unable to reproduce it and I've never seen it in another project either, so working backwards from a failing build is the only reasonable way it seems.