### PR TITLE
Exclude REMOTE_NAME from the item's metadata on a CSV bulk upload.

### DIFF
--- a/internetarchive/cli/ia_upload.py
+++ b/internetarchive/cli/ia_upload.py
@@ -266,6 +266,7 @@ def main(argv, session):
                 upload_kwargs_copy = deepcopy(upload_kwargs)
                 if row.get('REMOTE_NAME'):
                     local_file = {row['REMOTE_NAME']: row['file']}
+                    del row['REMOTE_NAME']
                 else:
                     local_file = row['file']
                 identifier = row.get('item', row.get('identifier'))


### PR DESCRIPTION
This prevents REMOTE_NAME, which has a special meaning during CSV bulk uploads, from appearing in an item's metadata during such uploads.

Closes: #416
