### PR TITLE
Give precedence to the most recent metadata during copy operations.

### DIFF
--- a/internetarchive/cli/ia_copy.py
+++ b/internetarchive/cli/ia_copy.py
@@ -114,6 +114,12 @@ def main(argv, session, cmd='copy'):
         args['--metadata'] = merge_dictionaries(SRC_ITEM.metadata,
                                                 args['--metadata'])
 
+    # File metadata is copied by default but can be dropped.
+    if args['--ignore-file-metadata']:
+        file_metadata = None
+    else:
+        file_metadata = SRC_FILE.metadata
+
     # Add keep-old-version by default.
     if 'x-archive-keep-old-version' not in args['--header']:
         args['--header']['x-archive-keep-old-version'] = '1'
@@ -122,8 +128,7 @@ def main(argv, session, cmd='copy'):
     req = ia.iarequest.S3Request(url=url,
                                  method='PUT',
                                  metadata=args['--metadata'],
-                                 file_metadata=(None if args['--ignore-file-metadata']
-                                                else SRC_FILE.metadata),
+                                 file_metadata=file_metadata,
                                  headers=args['--header'],
                                  access_key=session.access_key,
                                  secret_key=session.secret_key)

--- a/internetarchive/cli/ia_copy.py
+++ b/internetarchive/cli/ia_copy.py
@@ -118,6 +118,7 @@ def main(argv, session, cmd='copy'):
     req = ia.iarequest.S3Request(url=url,
                                  method='PUT',
                                  metadata=args['--metadata'],
+                                 file_metadata=SRC_FILE.metadata,
                                  headers=args['--header'],
                                  access_key=session.access_key,
                                  secret_key=session.secret_key)

--- a/internetarchive/cli/ia_copy.py
+++ b/internetarchive/cli/ia_copy.py
@@ -30,6 +30,7 @@ options:
     --replace-metadata             Only use metadata specified as argument,
                                    do not copy any from the source item.
     -H, --header=<key:value>...    S3 HTTP headers to send with your request.
+    --ignore-file-metadata         Do not copy file metadata.
 
 examples:
     # Turn off backups
@@ -88,6 +89,7 @@ def main(argv, session, cmd='copy'):
         '--replace-metadata': Use(bool),
         '--header': Or(None, And(Use(get_args_dict), dict),
                        error='--header must be formatted as --header="key:value"'),
+        '--ignore-file-metadata': Use(bool),
     })
 
     try:
@@ -118,7 +120,8 @@ def main(argv, session, cmd='copy'):
     req = ia.iarequest.S3Request(url=url,
                                  method='PUT',
                                  metadata=args['--metadata'],
-                                 file_metadata=SRC_FILE.metadata,
+                                 file_metadata=(None if args['--ignore-file-metadata']
+                                                else SRC_FILE.metadata),
                                  headers=args['--header'],
                                  access_key=session.access_key,
                                  secret_key=session.secret_key)

--- a/internetarchive/cli/ia_copy.py
+++ b/internetarchive/cli/ia_copy.py
@@ -2,7 +2,7 @@
 #
 # The internetarchive module is a Python/CLI interface to Archive.org.
 #
-# Copyright (C) 2012-2019 Internet Archive
+# Copyright (C) 2012-2021 Internet Archive
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/internetarchive/cli/ia_copy.py
+++ b/internetarchive/cli/ia_copy.py
@@ -104,9 +104,11 @@ def main(argv, session, cmd='copy'):
     args['--header']['x-amz-copy-source'] = '/{}'.format(parse.quote(src_path))
     # Copy the old metadata verbatim if no additional metadata is supplied,
     # else combine the old and the new metadata in a sensible manner.
-    args['--header']['x-amz-metadata-directive'] = ('REPLACE' if (args['--metadata']
-                                                                  or args['--replace-metadata'])
-                                                    else 'COPY')
+    if args['--metadata'] or args['--replace-metadata']:
+        args['--header']['x-amz-metadata-directive'] = 'REPLACE'
+    else:
+        args['--header']['x-amz-metadata-directive'] = 'COPY'
+
     # New metadata takes precedence over old metadata.
     if not args['--replace-metadata']:
         args['--metadata'] = merge_dictionaries(SRC_ITEM.metadata,

--- a/internetarchive/files.py
+++ b/internetarchive/files.py
@@ -2,7 +2,7 @@
 #
 # The internetarchive module is a Python/CLI interface to Archive.org.
 #
-# Copyright (C) 2012-2019 Internet Archive
+# Copyright (C) 2012-2021 Internet Archive
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/internetarchive/files.py
+++ b/internetarchive/files.py
@@ -68,6 +68,9 @@ class BaseFile(object):
 
         for key in file_metadata:
             setattr(self, key, file_metadata[key])
+        # An additional, more orderly way to access file metadata,
+        # which avoids filtering the attributes.
+        self.metadata = file_metadata
         self.mtime = float(self.mtime) if self.mtime else 0
         self.size = int(self.size) if self.size else 0
 

--- a/internetarchive/utils.py
+++ b/internetarchive/utils.py
@@ -372,14 +372,29 @@ def is_valid_metadata_key(name):
 
 
 def merge_dictionaries(dict0, dict1, keys_to_drop=None):
-    """Merge the dictionaries `dict0` and `dict1`, while giving precedence
-       to the items existing in `dict1`.
-       Additionally `keys_to_drop` is an optional list with keys that will
-       be dropped from `dict0` before the dictionaries are merged."""
+    """Merge two dictionaries.
+
+       Items in `dict0` can optionally be dropped before the merge.
+
+       If equal keys exist in both dictionaries,
+       entries in`dict0` are overwritten.
+
+       :type dict0: dict
+       :param dict0: A base dictionary with the bulk of the items.
+
+       :type dict1: dict
+       :param dict1: Additional items which overwrite the items in `dict0`.
+
+       :type keys_to_drop: iterable
+       :param keys_to_drop: An iterable of keys to drop from `dict0` before the merge.
+
+       :rtype: dict
+       :returns: A merged dictionary.
+       """
     new_dict = dict0.copy()
     if keys_to_drop is not None:
         for key in keys_to_drop:
             new_dict.pop(key, None)
-    # Items from dict1 take precedence over items from dict0.
+    # Items from `dict1` take precedence over items from `dict0`.
     new_dict.update(dict1)
     return new_dict

--- a/internetarchive/utils.py
+++ b/internetarchive/utils.py
@@ -369,3 +369,17 @@ def is_valid_metadata_key(name):
     # by an index in square brackets e. g. [0].
     # On the other hand the Archive allows tags starting with the string "xml".
     return bool(re.fullmatch('[A-Za-z][.\-0-9A-Za-z_]+(?:\[[0-9]+\])?', name))
+
+
+def merge_dictionaries(dict0, dict1, keys_to_drop=None):
+    """Merge the dictionaries `dict0` and `dict1`, while giving precedence
+       to the items existing in `dict1`.
+       Additionally `keys_to_drop` is an optional list with keys that will
+       be dropped from `dict0` before the dictionaries are merged."""
+    new_dict = dict0.copy()
+    if keys_to_drop is not None:
+        for key in keys_to_drop:
+            new_dict.pop(key, None)
+    # Items from dict1 take precedence over items from dict0.
+    new_dict.update(dict1)
+    return new_dict


### PR DESCRIPTION
When specifying metadata during a copy operation, any new metadata specified on the command line would be added to the item in addition to the fully copied original metadata which could lead to very bizarre results and even metadata conflicts unresolvable by regular users.

Now only the parts of the old metadata which don't conflict with newer metadata are copied.
File metadata is now also copied over.

It may or may not be desirable to have a more fine grained merge on some metadata keys for which it might make sense (e. g. the subjects), but I did not want to make that call at this time.

The new switch `--replace-metadata` drops all metadata from the original item and only uses metadata specified as argument to `ia` (or the default value).
The new switch `--ignore-file-metadata` prevents the copying of any file metadata.

Closes: #413