### PR TITLE
Documentation: Specify the maximum allowed length of identifiers.

### DIFF
--- a/docs/source/metadata.rst
+++ b/docs/source/metadata.rst
@@ -16,7 +16,7 @@ Please refer to the XML Naming Rules section `here <https://www.w3schools.com/xm
 Archive.org Identifiers
 -----------------------
 
-Each item at Internet Archive has an identifier. An identifier is composed of any unique combination of alphanumeric characters, underscore (``_``) and dash (``-``). While there are no official limits it is strongly suggested that identifiers be between 5 and 80 characters in length.
+Each item at Internet Archive has an identifier. An identifier is composed of any unique combination of alphanumeric characters, underscore (``_``) and dash (``-``). The maximum length of an identifier is 101 characters, but it is strongly suggested that identifiers be between 5 and 80 characters in length.
 
 Identifiers must be unique across the entirety of Internet Archive, not simply unique within a single collection.
 


### PR DESCRIPTION
The other Internet Archive documentation specifies the maximum length
as 100 characters, but actually it is 101 characters as you can test
by creating such an item and trying to create one which is greater
than 101 characters.

This is probably an off-by-one error in the Internet Archive program
which checks identifiers.

See: https://archive.org/services/docs/api/metadata-schema/index.html