### PR TITLE
Typo fix in Item.no_tasks_pending()

### DIFF
--- a/internetarchive/item.py
+++ b/internetarchive/item.py
@@ -256,7 +256,7 @@ class Item(BaseItem):
         :rtype: bool
         :returns: `True` if no tasks are pending, otherwise `False`.
         """
-        return all(x == 0 for x in self.task_summary(params, request_kwargs).values())
+        return all(x == 0 for x in self.get_task_summary(params, request_kwargs).values())
 
     def get_all_item_tasks(self, params=None, request_kwargs=None):
         """Get a list of all tasks for the item, pending and complete.


### PR DESCRIPTION
Fixes #433

The self.task_summary() method of Item does not exist.
But this method is used on the item_obj.no_tasks_pending() call, when working with the CLI.
Rename the Item.tasks_summary() call to the Item.get_task_summary() inside the Item.no_tasks_pending() method.