### PR TITLE
enable .json formats for uploading and metadata editing

### DIFF
--- a/internetarchive/cli/ia_metadata.py
+++ b/internetarchive/cli/ia_metadata.py
@@ -66,6 +66,7 @@ import six
 from internetarchive.cli.argparser import get_args_dict, get_args_dict_many_write,\
     get_args_header_dict
 from internetarchive.exceptions import ItemLocateError
+from internetarchive.utils import (is_json)
 
 # Only import backports.csv for Python2 (in support of FreeBSD port).
 PY2 = sys.version_info[0] == 2
@@ -270,8 +271,11 @@ def main(argv, session):
     if args['--spreadsheet']:
         if not args['--priority']:
             args['--priority'] = -5
-        with io.open(args['--spreadsheet'], 'rU', newline='', encoding='utf-8') as csvfp:
-            spreadsheet = csv.DictReader(csvfp)
+        with io.open(args['--spreadsheet'], 'rU', newline='', encoding='utf-8') as fp:
+            if is_json(args['--spreadsheet']):
+                spreadsheet = json.load(fp)
+            else:
+                spreadsheet = csv.DictReader(fp)
             responses = []
             for row in spreadsheet:
                 if not row['identifier']:

--- a/internetarchive/cli/ia_upload.py
+++ b/internetarchive/cli/ia_upload.py
@@ -78,7 +78,7 @@ from schema import Schema, Use, Or, And, SchemaError
 from internetarchive.cli.argparser import get_args_dict, convert_str_list_to_unicode
 from internetarchive.session import ArchiveSession
 from internetarchive.utils import (InvalidIdentifierException, get_s3_xml_text,
-                                   is_valid_metadata_key, validate_s3_identifier)
+                                   is_valid_metadata_key, validate_s3_identifier, is_json)
 
 # Only import backports.csv for Python2 (in support of FreeBSD port).
 PY2 = sys.version_info[0] == 2
@@ -260,8 +260,12 @@ def main(argv, session):
     # Bulk upload using spreadsheet.
     else:
         # Use the same session for each upload request.
-        with io.open(args['--spreadsheet'], 'rU', newline='', encoding='utf-8') as csvfp:
-            spreadsheet = csv.DictReader(csvfp)
+
+        with io.open(args['--spreadsheet'], 'rU', newline='', encoding='utf-8') as fp:
+            if is_json(args['--spreadsheet']):
+                spreadsheet = json.load(fp)
+            else:
+                spreadsheet = csv.DictReader(fp)
             prev_identifier = None
             for row in spreadsheet:
                 for metadata_key in row:

--- a/internetarchive/utils.py
+++ b/internetarchive/utils.py
@@ -398,3 +398,8 @@ def merge_dictionaries(dict0, dict1, keys_to_drop=None):
     # Items from `dict1` take precedence over items from `dict0`.
     new_dict.update(dict1)
     return new_dict
+
+
+def is_json(filename):
+    # Checks whether filetype is .json, else fallsback to .csv file format
+    return bool(re.fullmatch('^.*\.json$', filename))


### PR DESCRIPTION
it's a small edit of mine: i was having problems uploading files since it has commas on it. instead of fixing it with double quotes, i just tried editing the code. just a small one.

what it does is it checks *.json in the filename, else it's a *.csv. that's pretty much it.