### PR TITLE
Restore the CSV field validation.

### DIFF
--- a/internetarchive/cli/ia_upload.py
+++ b/internetarchive/cli/ia_upload.py
@@ -264,13 +264,11 @@ def main(argv, session):
             spreadsheet = csv.DictReader(csvfp)
             prev_identifier = None
             for row in spreadsheet:
-                # TODO: Add PY2 support to ``is_valid_metadata_key``,
-                # then we can turn this back on.
-                # for metadata_key in row:
-                #     if not is_valid_metadata_key(metadata_key):
-                #         print('error: "%s" is not a valid metadata key.' % metadata_key,
-                #               file=sys.stderr)
-                #         sys.exit(1)
+                for metadata_key in row:
+                    if not is_valid_metadata_key(metadata_key):
+                        print('error: "%s" is not a valid metadata key.' % metadata_key,
+                              file=sys.stderr)
+                        sys.exit(1)
                 upload_kwargs_copy = deepcopy(upload_kwargs)
                 if row.get('REMOTE_NAME'):
                     local_file = {row['REMOTE_NAME']: row['file']}

--- a/internetarchive/utils.py
+++ b/internetarchive/utils.py
@@ -368,7 +368,7 @@ def is_valid_metadata_key(name):
     # are way more restrictive and only allow ".-A-Za-z_", possibly followed
     # by an index in square brackets e. g. [0].
     # On the other hand the Archive allows tags starting with the string "xml".
-    return bool(re.fullmatch('[A-Za-z][.\-0-9A-Za-z_]+(?:\[[0-9]+\])?', name))
+    return bool(re.match('^[A-Za-z][.\-0-9A-Za-z_]+(?:\[[0-9]+\])?$', name))
 
 
 def merge_dictionaries(dict0, dict1, keys_to_drop=None):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -90,3 +90,19 @@ def test_get_file_size():
     with open(NASA_METADATA_PATH) as fp:
         s = internetarchive.utils.get_file_size(fp)
     assert s == 7557
+
+
+def test_is_valid_metadata_key():
+    # Keys starting with "xml" should also be invalid
+    # due to the XML specification, but are supported
+    # by the Internet Archive.
+    valid = ("adaptive_ocr", "bookreader-defaults", "frames_per_second",
+             "identifier", "possible-copyright-status", "index[0]")
+    invalid = ("Analog Format", "Date of transfer (probably today's date)",
+               "_metadata_key", "58", "_", "<invalid>", "a")
+
+    for metadata_key in valid:
+        assert internetarchive.utils.is_valid_metadata_key(metadata_key)
+
+    for metadata_key in invalid:
+        assert not internetarchive.utils.is_valid_metadata_key(metadata_key)


### PR DESCRIPTION
These commits fix the previous Python 2 incompatibility of `is_valid_metadata_key` by using a `re.match` expression which is anchored to have the same effect as the `re.fullmatch` expression.