### PR TITLE
Synchronise tested Python versions in tox.ini and .github/workflows/tox.yml

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.6', '3.7', '3.8', '3.9', '3.10', 'pypy-3.7']
+        python: ['2.7', '3.5', '3.6', '3.7', '3.8', '3.9', '3.10', 'pypy-3.7']
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,8 +3,8 @@
 Release History
 ---------------
 
-2.2.0 (?)
-+++++++++
+2.2.0 (2021-11-23)
+++++++++++++++++++
 
 **Features and Improvements**
 
@@ -16,6 +16,7 @@ Release History
 - Fixed bug in ``ArchiveSession`` object where domains weren't getting set properly for cookies.
   This caused archive.org cookies to be sent to other domains.
 - Fixed bug in URL param parser for CLI.
+- Fixed Python 2 bug in ``ia upload --spreadsheet``.
 
 2.1.0 (2021-08-25)
 ++++++++++++++++++

--- a/internetarchive/__init__.py
+++ b/internetarchive/__init__.py
@@ -37,7 +37,7 @@ Usage::
 from __future__ import absolute_import
 
 __title__ = 'internetarchive'
-__version__ = '2.2.0.dev3'
+__version__ = '2.2.0'
 __author__ = 'Jacob M. Johnson'
 __license__ = 'AGPL 3'
 __copyright__ = 'Copyright (C) 2012-2019 Internet Archive'

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py35,py36,py37,py38,py39,py310
+envlist = py27,py35,py36,py37,py38,py39,py310,pypy37
 
 [testenv]
 deps = -r tests/requirements.txt


### PR DESCRIPTION
#437 didn't use the same Python version in the GitHub Actions config as in the tox config. As a result, Python 2 and 3.5 aren't tested automatically on PRs etc.

This synchronises the two lists. Namely, it restores CPython 2 and 3.5 testing on GitHub Actions and adds PyPy to the tox configuration.

As expected (#435), installations on the versions 2.7 and 3.5 do not currently work due to dependencies no longer supporting those EOL versions, so those jobs will fail until they are fixed in further PRs. Unfortunately, GitHub Actions still doesn't support allowable failures (actions/toolkit#399), so this will show red crosses everywhere. I think that's preferable to not running the tests at all though, otherwise the code will likely break even further under those ancient Python versions, which makes a final compatibility release as desired by @jjjake in #435 harder.

NB, I made this commit on top of the v2.2.0 release, which isn't on master yet. #449 should likely be merged before this PR.