### PR TITLE
Fix tests for Python 2.7 and 3.5

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.6', '3.7', '3.8', '3.9', '3.10', 'pypy-3.7']
+        python: ['2.7', '3.5', '3.6', '3.7', '3.8', '3.9', '3.10', 'pypy-3.7']
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,8 +3,8 @@
 Release History
 ---------------
 
-2.2.0 (?)
-+++++++++
+2.2.0 (2021-11-23)
+++++++++++++++++++
 
 **Features and Improvements**
 
@@ -16,6 +16,7 @@ Release History
 - Fixed bug in ``ArchiveSession`` object where domains weren't getting set properly for cookies.
   This caused archive.org cookies to be sent to other domains.
 - Fixed bug in URL param parser for CLI.
+- Fixed Python 2 bug in ``ia upload --spreadsheet``.
 
 2.1.0 (2021-08-25)
 ++++++++++++++++++

--- a/internetarchive/__init__.py
+++ b/internetarchive/__init__.py
@@ -37,7 +37,7 @@ Usage::
 from __future__ import absolute_import
 
 __title__ = 'internetarchive'
-__version__ = '2.2.0.dev3'
+__version__ = '2.2.0'
 __author__ = 'Jacob M. Johnson'
 __license__ = 'AGPL 3'
 __copyright__ = 'Copyright (C) 2012-2019 Internet Archive'

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,5 +1,6 @@
 flake8==3.9.2; python_version < '3.6'
 flake8==4.0.1; python_version >= '3.6'
 pytest==4.6.11; python_version < '3.0'
-pytest==6.2.5; python_version >= '3.0'
+pytest==6.1.2; python_version >= '3.0' and python_version < '3.6'
+pytest==6.2.5; python_version >= '3.6'
 responses==0.14.0

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,4 +1,5 @@
-flake8>=4.0.1
+flake8==3.9.2; python_version < '3.6'
+flake8==4.0.1; python_version >= '3.6'
 pytest==4.6.11; python_version < '3.0'
 pytest==6.2.5; python_version >= '3.0'
 responses==0.14.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py35,py36,py37,py38,py39,py310
+envlist = py27,py35,py36,py37,py38,py39,py310,pypy37
 
 [testenv]
 deps = -r tests/requirements.txt


### PR DESCRIPTION
* Synchronise the tox and GitHub Actions configs so the Python 2.7 and 3.5 tests are executed again (see #450 for details)
* Fix test dependencies for Python 2.7 and 3.5

Written on top of the v2.2.0 commit, which is why that appears in here. #449 should probably be merged first, but I don't know how GitHub will handle that exactly.