### PR TITLE
test_item.py: Assert to avoid a pointless comparison ;-)

### DIFF
--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -182,7 +182,7 @@ def test_download_clobber(tmpdir, nasa_item):
         rsps.reset()
         rsps.add(responses.GET, DOWNLOAD_URL_RE, body='new test content')
         nasa_item.download(files='nasa_meta.xml')
-        load_file('nasa/nasa_meta.xml') == 'new test content'
+        assert load_file('nasa/nasa_meta.xml') == 'new test content'
 
 
 def test_download_checksum(tmpdir, caplog):


### PR DESCRIPTION
[flake8-bugbear](https://github.com/PyCQA/flake8-bugbear#flake8-bugbear) saz: _B015 Pointless comparison. This comparison does nothing but waste CPU instructions. Either prepend `assert` or remove it._