### PR TITLE
Fix possibly faulty values for domain and path in parsed cookies.

### DIFF
--- a/internetarchive/session.py
+++ b/internetarchive/session.py
@@ -112,8 +112,9 @@ class ArchiveSession(requests.sessions.Session):
             if not cookie_dict.get(ck):
                 continue
             cookie = create_cookie(ck, cookie_dict[ck],
-                                   domain=cookie_dict.get('domain'),
-                                   path=cookie_dict.get('path'))
+                                   # .archive.org might be a better domain.
+                                   domain=cookie_dict.get('domain', ''),
+                                   path=cookie_dict.get('path', '/'))
             self.cookies.set_cookie(cookie)
 
         self.secure = self.config.get('general', {}).get('secure', True)

--- a/internetarchive/session.py
+++ b/internetarchive/session.py
@@ -112,8 +112,7 @@ class ArchiveSession(requests.sessions.Session):
             if not cookie_dict.get(ck):
                 continue
             cookie = create_cookie(ck, cookie_dict[ck],
-                                   # .archive.org might be a better domain.
-                                   domain=cookie_dict.get('domain', ''),
+                                   domain=cookie_dict.get('domain', '.archive.org'),
                                    path=cookie_dict.get('path', '/'))
             self.cookies.set_cookie(cookie)
 

--- a/internetarchive/utils.py
+++ b/internetarchive/utils.py
@@ -412,7 +412,7 @@ def parse_dict_cookies(value):
         name, value = item.split('=', 1)
         result[name] = value
     if 'domain' not in result:
-        result['domain'] = ''  # .archive.org might be better.
+        result['domain'] = '.archive.org'
     if 'path' not in result:
         result['path'] = '/'
     return result

--- a/internetarchive/utils.py
+++ b/internetarchive/utils.py
@@ -411,4 +411,8 @@ def parse_dict_cookies(value):
             continue
         name, value = item.split('=', 1)
         result[name] = value
+    if 'domain' not in result:
+        result['domain'] = ''  # .archive.org might be better.
+    if 'path' not in result:
+        result['path'] = '/'
     return result


### PR DESCRIPTION
Using .archive.org as the default domain would be better,
but I'm not sure whether that covers all use cases.
@jjjake would have to chime in here.

Closes #452
Closes #455