### PR TITLE
Make the IA config file path configurable through the IA_CONFIG_FILE environment variable

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,13 @@
 Release History
 ---------------
 
+Unreleased
+++++++++++
+
+**Features and Improvements**
+
+- Added support for ``IA_CONFIG_FILE`` environment variable to specify the configuration file path.
+
 2.2.0 (2021-11-23)
 ++++++++++++++++++
 

--- a/internetarchive/cli/ia.py
+++ b/internetarchive/cli/ia.py
@@ -28,7 +28,9 @@ usage:
 options:
     -h, --help
     -v, --version
-    -c, --config-file FILE  Use FILE as config file.
+    -c, --config-file FILE  Use FILE as config file. (Can also be set with the
+                            IA_CONFIG_FILE environment variable. The option takes
+                            precedence when both are used.)
     -l, --log               Turn on logging [default: False].
     -d, --debug             Turn on verbose logging [default: False].
     -i, --insecure          Use HTTP for all requests instead of HTTPS [default: false]

--- a/internetarchive/config.py
+++ b/internetarchive/config.py
@@ -121,6 +121,9 @@ def parse_config_file(config_file=None):
 
     is_xdg = False
     if not config_file:
+        candidates = []
+        if os.environ.get('IA_CONFIG_FILE'):
+            candidates.append(os.environ['IA_CONFIG_FILE'])
         xdg_config_home = os.environ.get('XDG_CONFIG_HOME')
         if not xdg_config_home or not os.path.isabs(xdg_config_home):
             # Per the XDG Base Dir specification, this should be $HOME/.config. Unfortunately, $HOME
@@ -128,15 +131,16 @@ def parse_config_file(config_file=None):
             # system, where $HOME must always be set, the XDG spec will be followed precisely.
             xdg_config_home = os.path.join(os.path.expanduser('~'), '.config')
         xdg_config_file = os.path.join(xdg_config_home, 'internetarchive', 'ia.ini')
-        for candidate in [xdg_config_file,
-                          os.path.join(os.path.expanduser('~'), '.config', 'ia.ini'),
-                          os.path.join(os.path.expanduser('~'), '.ia')]:
+        candidates.append(xdg_config_file)
+        candidates.append(os.path.join(os.path.expanduser('~'), '.config', 'ia.ini'))
+        candidates.append(os.path.join(os.path.expanduser('~'), '.ia'))
+        for candidate in candidates:
             if os.path.isfile(candidate):
                 config_file = candidate
                 break
         else:
-            # None of the candidates exist, default to XDG
-            config_file = xdg_config_file
+            # None of the candidates exist, default to IA_CONFIG_FILE if set else XDG
+            config_file = os.environ.get('IA_CONFIG_FILE', xdg_config_file)
         if config_file == xdg_config_file:
             is_xdg = True
     config.read(config_file)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -318,6 +318,21 @@ def test_parse_config_file_direct_path_overrides_existing_files():
     )
 
 
+def test_parse_config_file_with_environment_variable():
+    with _environ(IA_CONFIG_FILE='/inexistent.ia.ini'):
+        _test_parse_config_file(
+            expected_result=('/inexistent.ia.ini', False),
+        )
+
+
+def test_parse_config_file_with_environment_variable_and_parameter():
+    with _environ(IA_CONFIG_FILE='/inexistent.ia.ini'):
+        _test_parse_config_file(
+            expected_result=('/inexistent.other.ia.ini', False),
+            config_file_param='/inexistent.other.ia.ini',
+        )
+
+
 def _test_write_config_file(
         expected_config_file,
         expected_modes,


### PR DESCRIPTION
This change allows setting the IA config file path through an environment variable `IA_CONFIG_FILE` rather than only through the `--config-file` option. When both are present, the option takes precedence.

The motivation for this PR stems from script usage of `ia` and the occasional need for specifying a non-default configuration file path. In the past, I worked around this with a wrapper script which invokes `ia` with `--config-file`, but that approach has its own downsides (e.g. requiring either a hardcoded full path or fragile `PATH` modifications). Another way would be to override `HOME` or `XDG_CONFIG_HOME`, which is all sorts of wrong. I feel like this is a much cleaner solution.