### PR TITLE
Fix 'invalid escape sequence' DeprecationWarnings

### DIFF
--- a/internetarchive/api.py
+++ b/internetarchive/api.py
@@ -122,7 +122,7 @@ def get_files(identifier,
               glob_pattern=None,
               on_the_fly=None,
               **get_item_kwargs):
-    """Get :class:`File` objects from an item.
+    r"""Get :class:`File` objects from an item.
 
     :type identifier: str
     :param identifier: The globally unique Archive.org identifier for a given item.
@@ -162,7 +162,7 @@ def modify_metadata(identifier, metadata,
                     debug=None,
                     request_kwargs=None,
                     **get_item_kwargs):
-    """Modify the metadata of an existing item on Archive.org.
+    r"""Modify the metadata of an existing item on Archive.org.
 
     :type identifier: str
     :param identifier: The globally unique Archive.org identifier for a given item.
@@ -227,7 +227,7 @@ def upload(identifier, files,
            validate_identifier=None,
            request_kwargs=None,
            **get_item_kwargs):
-    """Upload files to an item. The item will be created if it does not exist.
+    r"""Upload files to an item. The item will be created if it does not exist.
 
     :type identifier: str
     :param identifier: The globally unique Archive.org identifier for a given item.
@@ -321,7 +321,7 @@ def download(identifier,
              return_responses=None,
              no_change_timestamp=None,
              **get_item_kwargs):
-    """Download files from an item.
+    r"""Download files from an item.
 
     :type identifier: str
     :param identifier: The globally unique Archive.org identifier for a given item.

--- a/internetarchive/item.py
+++ b/internetarchive/item.py
@@ -1133,7 +1133,7 @@ class Item(BaseItem):
                debug=None,
                validate_identifier=None,
                request_kwargs=None):
-        """Upload files to an item. The item will be created if it
+        r"""Upload files to an item. The item will be created if it
         does not exist.
 
         :type files: str, file, list, tuple, dict
@@ -1158,9 +1158,9 @@ class Item(BaseItem):
         Uploading file objects:
 
             >>> import io
-            >>> f = io.BytesIO(b"some initial binary data: \\x00\\x01")
+            >>> f = io.BytesIO(b"some initial binary data: \x00\x01")
             >>> r = item.upload({'remote-name.txt': f})
-            >>> f = io.BytesIO(b"some more binary data: \\x00\\x01")
+            >>> f = io.BytesIO(b"some more binary data: \x00\x01")
             >>> f.name = 'remote-name.txt'
             >>> r = item.upload(f)
 

--- a/internetarchive/utils.py
+++ b/internetarchive/utils.py
@@ -368,7 +368,7 @@ def is_valid_metadata_key(name):
     # are way more restrictive and only allow ".-A-Za-z_", possibly followed
     # by an index in square brackets e. g. [0].
     # On the other hand the Archive allows tags starting with the string "xml".
-    return bool(re.match('^[A-Za-z][.\-0-9A-Za-z_]+(?:\[[0-9]+\])?$', name))
+    return bool(re.match(r'^[A-Za-z][.\-0-9A-Za-z_]+(?:\[[0-9]+\])?$', name))
 
 
 def merge_dictionaries(dict0, dict1, keys_to_drop=None):


### PR DESCRIPTION
Since Python 3.6, invalid escape sequences in strings cause a DeprecationWarning (see test suite runs), which will eventually turn into a SyntaxError in some future Python version. When that will happen is not known yet, but let's fix those warnings before things blow up, shall we? :-)

I opted to go with raw strings for the docstrings which use `\*\*kwargs` reStructuredText escaping rather than escaping the backslashes since that seems more readable.