### PR TITLE
Fix for #330

### DIFF
--- a/internetarchive/item.py
+++ b/internetarchive/item.py
@@ -733,7 +733,10 @@ class Item(BaseItem):
             if no_directory:
                 path = f.name
             else:
-                path = os.path.join(self.identifier, f.name)
+                if os.name == 'nt' and self.identifier.endswith('.'):
+                    path = os.path.join(self.identifier.rstrip('.'), f.name)
+                else:
+                    path = os.path.join(self.identifier, f.name)
             if dry_run:
                 print(f.url)
                 continue


### PR DESCRIPTION
Hopefully this is a good fix for https://github.com/jjjake/internetarchive/issues/330, however I'm unsure if we should either remove the trailing periods or replace them with underscores - your call. The bug happens due to Windows not allowing trailing periods in folder names.