### PR TITLE
Clean up JSON package importing to use ujson throughout when available

### DIFF
--- a/internetarchive/catalog.py
+++ b/internetarchive/catalog.py
@@ -26,10 +26,6 @@ This module contains objects for interacting with the Archive.org catalog.
 :copyright: (C) 2012-2019 by Internet Archive.
 :license: AGPL 3, see LICENSE for more details.
 """
-try:
-    import ujson as json
-except ImportError:
-    import json
 from logging import getLogger
 from datetime import datetime
 
@@ -37,6 +33,7 @@ from requests.exceptions import HTTPError
 import collections
 
 from internetarchive import auth
+from internetarchive.utils import json
 
 
 log = getLogger(__name__)

--- a/internetarchive/cli/ia_metadata.py
+++ b/internetarchive/cli/ia_metadata.py
@@ -50,10 +50,6 @@ options:
 """
 import sys
 import os
-try:
-    import ujson as json
-except ImportError:
-    import json
 import io
 from collections import defaultdict
 from copy import copy
@@ -65,6 +61,7 @@ from schema import Schema, SchemaError, Or, And, Use
 from internetarchive.cli.argparser import get_args_dict, get_args_dict_many_write,\
     get_args_header_dict
 from internetarchive.exceptions import ItemLocateError
+from internetarchive.utils import json
 
 
 def modify_metadata(item, metadata, args):

--- a/internetarchive/cli/ia_search.py
+++ b/internetarchive/cli/ia_search.py
@@ -39,10 +39,6 @@ options:
     -t, --timeout=<seconds>          Set the timeout in seconds [default: 300].
 """
 import sys
-try:
-    import ujson as json
-except ImportError:
-    import json
 from itertools import chain
 
 from docopt import docopt, printable_usage
@@ -52,6 +48,7 @@ from requests.exceptions import ConnectTimeout, ReadTimeout
 from internetarchive import search_items
 from internetarchive.cli.argparser import get_args_dict
 from internetarchive.exceptions import AuthenticationError
+from internetarchive.utils import json
 
 
 def main(argv, session=None):

--- a/internetarchive/cli/ia_tasks.py
+++ b/internetarchive/cli/ia_tasks.py
@@ -67,11 +67,11 @@ examples:
 """
 import sys
 import warnings
-import json
 
 from docopt import docopt
 
 from internetarchive.cli.argparser import get_args_dict
+from internetarchive.utils import json
 
 
 def main(argv, session):

--- a/internetarchive/cli/ia_upload.py
+++ b/internetarchive/cli/ia_upload.py
@@ -66,7 +66,6 @@ import sys
 from tempfile import TemporaryFile
 from copy import deepcopy
 import webbrowser
-import json
 import csv
 
 from docopt import docopt, printable_usage
@@ -75,8 +74,8 @@ from schema import Schema, Use, Or, And, SchemaError
 
 from internetarchive.cli.argparser import get_args_dict, convert_str_list_to_unicode
 from internetarchive.session import ArchiveSession
-from internetarchive.utils import (InvalidIdentifierException, get_s3_xml_text,
-                                   is_valid_metadata_key, validate_s3_identifier)
+from internetarchive.utils import (InvalidIdentifierException, JSONDecodeError, get_s3_xml_text,
+                                   is_valid_metadata_key, json, validate_s3_identifier)
 
 
 def _upload_files(item, files, upload_kwargs, prev_identifier=None, archive_session=None):
@@ -197,7 +196,7 @@ def main(argv, session):
     if args['--file-metadata']:
         try:
             args['<file>'] = json.load(open(args['--file-metadata']))
-        except json.decoder.JSONDecodeError:
+        except JSONDecodeError:
             args['<file>'] = []
             for line in open(args['--file-metadata']):
                 j = json.loads(line.strip())

--- a/internetarchive/iarequest.py
+++ b/internetarchive/iarequest.py
@@ -24,10 +24,6 @@ internetarchive.iarequest
 :copyright: (C) 2012-2021 by Internet Archive.
 :license: AGPL 3, see LICENSE for more details.
 """
-try:
-    import ujson as json
-except ImportError:
-    import json
 import re
 import copy
 import logging
@@ -37,7 +33,7 @@ import requests
 from jsonpatch import make_patch
 
 from internetarchive import auth, __version__
-from internetarchive.utils import needs_quote, delete_items_from_dict
+from internetarchive.utils import json, needs_quote, delete_items_from_dict
 from internetarchive.exceptions import ItemLocateError
 
 

--- a/internetarchive/item.py
+++ b/internetarchive/item.py
@@ -33,7 +33,6 @@ import math
 from xml.parsers.expat import ExpatError
 
 from functools import total_ordering
-import json
 from copy import deepcopy
 
 from urllib.parse import quote
@@ -44,7 +43,7 @@ from requests.exceptions import HTTPError
 from internetarchive.utils import (IdentifierListAsItems, get_md5,
                                    chunk_generator, IterableToFileAdapter,
                                    iter_directory, recursive_file_count,
-                                   norm_filepath)
+                                   norm_filepath, json)
 from internetarchive.files import File
 from internetarchive.iarequest import MetadataRequest, S3Request
 from internetarchive.auth import S3Auth

--- a/internetarchive/session.py
+++ b/internetarchive/session.py
@@ -33,10 +33,6 @@ import sys
 import logging
 import platform
 import warnings
-try:
-    import ujson as json
-except ImportError:
-    import json
 
 import requests.sessions
 from requests.utils import default_headers

--- a/internetarchive/utils.py
+++ b/internetarchive/utils.py
@@ -34,6 +34,16 @@ from xml.dom.minidom import parseString
 from collections.abc import Mapping
 
 
+# Make preferred JSON package available via `from internetarchive.utils import json`
+try:
+    import ujson as json
+    # ujson lacks a JSONDecodeError: https://github.com/ultrajson/ultrajson/issues/497
+    JSONDecodeError = ValueError
+except ImportError:
+    import json
+    JSONDecodeError = json.JSONDecodeError
+
+
 def deep_update(d, u):
     for k, v in u.items():
         if isinstance(v, Mapping):

--- a/tests/cli/test_ia_search.py
+++ b/tests/cli/test_ia_search.py
@@ -1,10 +1,7 @@
 from tests.conftest import PROTOCOL, load_test_data_file, IaRequestsMock, ia_call
 
-try:
-    import ujson as json
-except ImportError:
-    import json
 
+from internetarchive.utils import json
 import responses
 
 

--- a/tests/cli/test_ia_upload.py
+++ b/tests/cli/test_ia_upload.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
-import json
-
 import responses
 
+from internetarchive.utils import json
 from tests.conftest import IaRequestsMock, load_test_data_file, ia_call
 
 PROTOCOL = 'https:'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,3 @@
-import json
 import os
 import re
 import sys
@@ -11,6 +10,7 @@ from responses import RequestsMock
 from internetarchive import get_session
 from internetarchive.api import get_item
 from internetarchive.cli import ia
+from internetarchive.utils import json
 
 try:
     FileNotFoundError

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-import json
 import os
 import re
 
@@ -9,7 +8,7 @@ from requests.packages import urllib3
 from internetarchive import (get_session, get_item, get_files, modify_metadata,
                              upload, download, search_items)
 
-from internetarchive.utils import InvalidIdentifierException
+from internetarchive.utils import InvalidIdentifierException, json
 from tests.conftest import (NASA_METADATA_PATH, PROTOCOL, IaRequestsMock,
                             load_test_data_file, load_file)
 

--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -4,10 +4,6 @@ from internetarchive.utils import norm_filepath, InvalidIdentifierException
 from tests.conftest import (PROTOCOL, IaRequestsMock, load_file,
                             NASA_METADATA_PATH, load_test_data_file)
 
-try:
-    import ujson as json
-except ImportError:
-    import json
 import types
 import re
 import os
@@ -19,6 +15,7 @@ from requests.exceptions import HTTPError, ConnectionError
 
 from internetarchive import get_session
 import internetarchive.files
+from internetarchive.utils import json
 
 S3_URL = f'{PROTOCOL}//s3.us.archive.org/'
 DOWNLOAD_URL_RE = re.compile(f'{PROTOCOL}//archive.org/download/.*')
@@ -592,7 +589,8 @@ def test_modify_metadata(nasa_item, nasa_metadata):
         assert set(p.data.keys()) == set(expected_data.keys())
         assert p.data['priority'] == expected_data['priority']
         assert p.data['-target'] == expected_data['-target']
-        assert '["one", "two", "last"]' in str(p.data['-patch'])
+        assert '["one", "two", "last"]' in str(p.data['-patch']) \
+               or '["one","two","last"]' in str(p.data['-patch'])
 
         # Test indexed mod.
         nasa_item.item_metadata['metadata']['subject'] = ['first', 'middle', 'last']
@@ -607,7 +605,7 @@ def test_modify_metadata(nasa_item, nasa_metadata):
         # Avoid comparing the json strings, because they are not in a canonical form
         assert set(p.data.keys()) == set(expected_data.keys())
         assert all(p.data[k] == expected_data[k] for k in ['priority', '-target'])
-        assert '/subject/2' in p.data['-patch']
+        assert '/subject/2' in p.data['-patch'] or r'\/subject\/2' in p.data['-patch']
 
         # Test priority.
         md = {'title': 'NASA Images'}


### PR DESCRIPTION
* ujson was only being used in some places previously and not others.
* The upload CLI used the undocumented `json.decoder.JSONDecodeError`.
* `tests/test_item.py::test_download_checksum` was broken when run with ujson due to different but equivalent encoding.