### PR TITLE
Clean up quote usage

### DIFF
--- a/internetarchive/cli/ia_metadata.py
+++ b/internetarchive/cli/ia_metadata.py
@@ -218,8 +218,8 @@ def main(argv, session):
                 if any('/' in k for k in metadata):
                     metadata = get_args_dict_many_write(metadata)
             except ValueError:
-                print("error: The value of --modify, --remove, --append or --append-list "
-                      "is invalid. It must be formatted as: --modify=key:value",
+                print('error: The value of --modify, --remove, --append or --append-list '
+                      'is invalid. It must be formatted as: --modify=key:value',
                       file=sys.stderr)
                 sys.exit(1)
 

--- a/internetarchive/item.py
+++ b/internetarchive/item.py
@@ -1136,9 +1136,9 @@ class Item(BaseItem):
         Uploading file objects:
 
             >>> import io
-            >>> f = io.BytesIO(b"some initial binary data: \x00\x01")
+            >>> f = io.BytesIO(b'some initial binary data: \x00\x01')
             >>> r = item.upload({'remote-name.txt': f})
-            >>> f = io.BytesIO(b"some more binary data: \x00\x01")
+            >>> f = io.BytesIO(b'some more binary data: \x00\x01')
             >>> f.name = 'remote-name.txt'
             >>> r = item.upload(f)
 

--- a/tests/cli/test_argparser.py
+++ b/tests/cli/test_argparser.py
@@ -5,7 +5,7 @@ from internetarchive.cli.argparser import get_args_dict
 def test_get_args_dict():
     test_input = [
         'collection:test_collection',
-        "description: Attention: multiple colons",
+        'description: Attention: multiple colons',
         'unicode_test:தமிழ்',
         'subject:subject1, subject1',
         'subject:subject2',
@@ -13,7 +13,7 @@ def test_get_args_dict():
     ]
     test_output = {
         'collection': 'test_collection',
-        'description': " Attention: multiple colons",
+        'description': ' Attention: multiple colons',
         'unicode_test': 'தமிழ்',
         'subject': ['subject1, subject1', 'subject2', 'subject3; subject3'],
     }

--- a/tests/cli/test_ia_list.py
+++ b/tests/cli/test_ia_list.py
@@ -84,7 +84,7 @@ def test_ia_list_format(capsys, nasa_mocker):
 
 def test_ia_list_non_existing(capsys):
     with IaRequestsMock() as rsps:
-        rsps.add_metadata_mock('nasa', body="{}")
+        rsps.add_metadata_mock('nasa', body='{}')
         try:
             ia_list.main(['list', 'nasa'], SESSION)
         except SystemExit as exc:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -29,7 +29,7 @@ def test_get_session_with_config():
 
 def test_get_session_with_config_file(tmpdir):
     tmpdir.chdir()
-    test_conf = """[s3]\naccess = key2"""
+    test_conf = '[s3]\naccess = key2'
     with open('ia_test.ini', 'w') as fh:
         fh.write(test_conf)
     s = get_session(config_file='ia_test.ini')
@@ -48,7 +48,7 @@ def test_get_item_with_config(nasa_mocker):
 
 def test_get_item_with_config_file(tmpdir, nasa_mocker):
     tmpdir.chdir()
-    test_conf = """[s3]\naccess = key2"""
+    test_conf = '[s3]\naccess = key2'
     with open('ia_test.ini', 'w') as fh:
         fh.write(test_conf)
 
@@ -107,7 +107,7 @@ def test_get_files_with_get_item_kwargs(tmpdir):
         assert len(files) == 1
         assert files[0].name == 'nasa_meta.xml'
 
-        test_conf = """[s3]\naccess = key2"""
+        test_conf = '[s3]\naccess = key2'
         with open('ia_test.ini', 'w') as fh:
             fh.write(test_conf)
         files = get_files('nasa', files='nasa_meta.xml',

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -350,7 +350,7 @@ def _test_write_config_file(
 
 
 def test_write_config_file_blank():
-    '''Test that a blank HOME is populated with expected dirs and modes.'''
+    """Test that a blank HOME is populated with expected dirs and modes."""
     _test_write_config_file(
         expected_config_file='.config/internetarchive/ia.ini',
         expected_modes=[
@@ -362,7 +362,7 @@ def test_write_config_file_blank():
 
 
 def test_write_config_file_config_existing():
-    '''Test that .config's permissions remain but ia gets created correctly.'''
+    """Test that .config's permissions remain but ia gets created correctly."""
     _test_write_config_file(
         dirs=['.config'],
         expected_config_file='.config/internetarchive/ia.ini',
@@ -375,7 +375,7 @@ def test_write_config_file_config_existing():
 
 
 def test_write_config_file_config_internetarchive_existing():
-    '''Test that directory permissions are left as is'''
+    """Test that directory permissions are left as is"""
     _test_write_config_file(
         dirs=['.config', '.config/internetarchive'],
         expected_config_file='.config/internetarchive/ia.ini',
@@ -388,7 +388,7 @@ def test_write_config_file_config_internetarchive_existing():
 
 
 def test_write_config_file_existing_file():
-    '''Test that the permissions of the file are forced to 600'''
+    """Test that the permissions of the file are forced to 600"""
     _test_write_config_file(
         dirs=['.config', '.config/internetarchive'],
         expected_config_file='.config/internetarchive/ia.ini',
@@ -402,7 +402,7 @@ def test_write_config_file_existing_file():
 
 
 def test_write_config_file_existing_other_file():
-    '''Test that the permissions of the file are forced to 600 even outside XDG'''
+    """Test that the permissions of the file are forced to 600 even outside XDG"""
     _test_write_config_file(
         dirs=['foo'],
         expected_config_file='foo/ia.ini',
@@ -416,7 +416,7 @@ def test_write_config_file_existing_other_file():
 
 
 def test_write_config_file_custom_path_existing():
-    '''Test the creation of a config file at a custom location'''
+    """Test the creation of a config file at a custom location"""
     _test_write_config_file(
         dirs=['foo'],
         expected_config_file='foo/ia.ini',
@@ -429,7 +429,7 @@ def test_write_config_file_custom_path_existing():
 
 
 def test_write_config_file_custom_path_not_existing():
-    '''Ensure that an exception is thrown if the custom path dir doesn't exist'''
+    """Ensure that an exception is thrown if the custom path dir doesn't exist"""
     with tempfile.TemporaryDirectory() as temp_home_dir:
         with _environ(HOME=temp_home_dir):
             config_file = os.path.join(temp_home_dir, 'foo/ia.ini')

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -5,4 +5,4 @@ def test_AuthenticationError():
     try:
         raise internetarchive.exceptions.AuthenticationError('Authentication Failed')
     except Exception as exc:
-        assert str(exc) == """Authentication Failed"""
+        assert str(exc) == 'Authentication Failed'

--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -551,7 +551,7 @@ def test_modify_metadata(nasa_item, nasa_metadata):
         md = {'foo': 'bar'}
         p = nasa_item.modify_metadata(md, debug=True)
         _patch = json.dumps([
-            {"add": "/foo", "value": "bar"},
+            {'add': '/foo', 'value': 'bar'},
         ])
         expected_data = {
             'priority': -5,
@@ -573,7 +573,7 @@ def test_modify_metadata(nasa_item, nasa_metadata):
         expected_data = {
             'priority': -5,
             '-target': 'metadata',
-            '-patch': json.dumps([{"remove": "/title"}])
+            '-patch': json.dumps([{'remove': '/title'}])
         }
         assert set(p.data.keys()) == set(expected_data.keys())
         assert p.data['priority'] == expected_data['priority']
@@ -587,7 +587,7 @@ def test_modify_metadata(nasa_item, nasa_metadata):
         expected_data = {
             'priority': -1,
             '-target': 'metadata',
-            '-patch': json.dumps([{"add": "/subject", "value": ["one", "two", "last"]}])
+            '-patch': json.dumps([{'add': '/subject', 'value': ['one', 'two', 'last']}])
         }
         assert set(p.data.keys()) == set(expected_data.keys())
         assert p.data['priority'] == expected_data['priority']
@@ -601,7 +601,7 @@ def test_modify_metadata(nasa_item, nasa_metadata):
         expected_data = {
             'priority': -5,
             '-target': 'metadata',
-            '-patch': json.dumps([{"value": "new first", "replace": "/subject/2"}])
+            '-patch': json.dumps([{'value': 'new first', 'replace': '/subject/2'}])
         }
 
         # Avoid comparing the json strings, because they are not in a canonical form

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -86,10 +86,10 @@ def test_is_valid_metadata_key():
     # Keys starting with "xml" should also be invalid
     # due to the XML specification, but are supported
     # by the Internet Archive.
-    valid = ("adaptive_ocr", "bookreader-defaults", "frames_per_second",
-             "identifier", "possible-copyright-status", "index[0]")
-    invalid = ("Analog Format", "Date of transfer (probably today's date)",
-               "_metadata_key", "58", "_", "<invalid>", "a")
+    valid = ('adaptive_ocr', 'bookreader-defaults', 'frames_per_second',
+             'identifier', 'possible-copyright-status', 'index[0]')
+    invalid = ('Analog Format', "Date of transfer (probably today's date)",
+               '_metadata_key', '58', '_', '<invalid>', 'a')
 
     for metadata_key in valid:
         assert internetarchive.utils.is_valid_metadata_key(metadata_key)


### PR DESCRIPTION
Single-quoted strings are *far* more common across the code base by at least a factor 10 based on some grepping, except for multi-line strings, which almost consistently use triple double quotes. This cleans up the few inconsistencies (except where double quotes are needed due to strings containing single quotes).