### PR TITLE
Fix `ia upload --debug` only displaying the first request

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -18,6 +18,7 @@ Unreleased
 **Bugfixes**
 
 - Fixed treatment of list-like file metadata in ``ia list`` under Python 3
+- Fixed `ia upload --debug` only displaying the first request.
 
 2.3.0 (2022-01-20)
 ++++++++++++++++++

--- a/internetarchive/cli/ia_upload.py
+++ b/internetarchive/cli/ia_upload.py
@@ -104,7 +104,7 @@ def _upload_files(item, files, upload_kwargs, prev_identifier=None, archive_sess
                 )
                 print(f'Endpoint:\n {r.url}\n')
                 print(f'HTTP Headers:\n{headers}')
-                return responses
+            return responses
 
         # Format error message for any non 200 responses that
         # we haven't caught yet,and write to stderr.


### PR DESCRIPTION
Fixes #254