### PR TITLE
Fix uploading from stdin crashing with UnicodeDecodeError or TypeError

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -19,6 +19,7 @@ Unreleased
 
 - Fixed treatment of list-like file metadata in ``ia list`` under Python 3
 - Fixed `ia upload --debug` only displaying the first request.
+- Fixed uploading from stdin crashing with UnicodeDecodeError or TypeError exception.
 
 2.3.0 (2022-01-20)
 ++++++++++++++++++


### PR DESCRIPTION
This also reads only 1 MiB at a time instead of buffering the entire input in memory, which can be problematic with large uploads.

Fixes #432