### PR TITLE
Clean up usage of `open()`

### DIFF
--- a/internetarchive/cli/ia_metadata.py
+++ b/internetarchive/cli/ia_metadata.py
@@ -50,7 +50,6 @@ options:
 """
 import sys
 import os
-import io
 from collections import defaultdict
 from copy import copy
 import csv
@@ -254,7 +253,7 @@ def main(argv, session):
     if args['--spreadsheet']:
         if not args['--priority']:
             args['--priority'] = -5
-        with io.open(args['--spreadsheet'], 'rU', newline='', encoding='utf-8') as csvfp:
+        with open(args['--spreadsheet'], 'r', newline='', encoding='utf-8') as csvfp:
             spreadsheet = csv.DictReader(csvfp)
             responses = []
             for row in spreadsheet:

--- a/internetarchive/cli/ia_upload.py
+++ b/internetarchive/cli/ia_upload.py
@@ -60,7 +60,6 @@ options:
                                          will not be saved to history/files/$key.~N~
                                          [default: True].
 """
-import io
 import os
 import sys
 from tempfile import TemporaryFile
@@ -195,12 +194,14 @@ def main(argv, session):
 
     if args['--file-metadata']:
         try:
-            args['<file>'] = json.load(open(args['--file-metadata']))
+            with open(args['--file-metadata']) as fh:
+                args['<file>'] = json.load(fh)
         except JSONDecodeError:
             args['<file>'] = []
-            for line in open(args['--file-metadata']):
-                j = json.loads(line.strip())
-                args['<file>'].append(j)
+            with open(args['--file-metadata']) as fh:
+                for line in fh:
+                    j = json.loads(line.strip())
+                    args['<file>'].append(j)
     upload_kwargs = {
         'metadata': args['--metadata'],
         'headers': args['--header'],
@@ -244,7 +245,7 @@ def main(argv, session):
     # Bulk upload using spreadsheet.
     else:
         # Use the same session for each upload request.
-        with io.open(args['--spreadsheet'], 'rU', newline='', encoding='utf-8') as csvfp:
+        with open(args['--spreadsheet'], 'r', newline='', encoding='utf-8') as csvfp:
             spreadsheet = csv.DictReader(csvfp)
             prev_identifier = None
             for row in spreadsheet:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-import io
 import string
 
 from tests.conftest import IaRequestsMock, NASA_METADATA_PATH
@@ -8,7 +7,9 @@ import internetarchive.utils
 
 
 def test_utils():
-    list(internetarchive.utils.chunk_generator(io.open(__file__, encoding='utf-8'), 10))
+    with open(__file__, encoding='utf-8') as fh:
+        list(internetarchive.utils.chunk_generator(fh, 10))
+
     ifp = internetarchive.utils.IterableToFileAdapter([1, 2], 200)
     assert len(ifp) == 200
     ifp.read()


### PR DESCRIPTION
* Get rid of `io.open`, which is an alias for `open` in Python 3.
* Remove obsolete 'U' mode, which has no effect in Python 3.
* Use context managers so the files get closed properly.