### PR TITLE
Overhaul `ia upload` to fix a number of bugs

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -20,6 +20,11 @@ Unreleased
 - Fixed treatment of list-like file metadata in ``ia list`` under Python 3
 - Fixed `ia upload --debug` only displaying the first request.
 - Fixed uploading from stdin crashing with UnicodeDecodeError or TypeError exception.
+- Fixed ``ia upload`` silently ignoring exceptions.
+- Fixed uploading from a spreadsheet with a BOM (UTF-8 byte-order mark) raising a KeyError.
+- Fixed uploading from a spreadsheet not reusing the ``identifier`` column.
+- Fixed uploading from a spreadsheet not correctly dropping the ``item`` column from metadata.
+- Fixed uploading from a spreadsheet with ``--checksum`` crashing on skipped files.
 
 2.3.0 (2022-01-20)
 ++++++++++++++++++

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -87,10 +87,12 @@ def call_cmd(cmd, expected_exit_code=0):
 
 class IaRequestsMock(RequestsMock):
     def add_metadata_mock(self, identifier, body=None, method=responses.GET,
-                          protocol='https?'):
+                          protocol='https?', transform_body=None):
         url = re.compile(f'{protocol}://archive.org/metadata/{identifier}')
         if body is None:
             body = load_test_data_file(f'metadata/{identifier}.json')
+        if transform_body:
+            body = transform_body(body)
         self.add(method, url, body=body, content_type='application/json')
 
     def mock_all_downloads(self, num_calls=1, body='test content', protocol='https?'):


### PR DESCRIPTION
* Returning from the `finally` clause in `_upload_files` silenced various exceptions
* Remove dead code in that same clause (made obsolete by 12bfdbac)
* Accept BOM in spreadsheets (#328)
* Reuse previous `identifier` (or `item`) column values in spreadsheets (#339)
* Fix `item` column not being dropped from metadata on spreadsheet uploads
* Fix TypeError crash on spreadsheet uploads with `--checksum` when a file is skipped (#393)
* Add tests for all of the above and some other previously untested usages of `ia upload`

Fixes #328
Fixes #339
Fixes #393