### PR TITLE
Revert a change which was made to accommodate Python 2.

### DIFF
--- a/internetarchive/utils.py
+++ b/internetarchive/utils.py
@@ -2,7 +2,7 @@
 #
 # The internetarchive module is a Python/CLI interface to Archive.org.
 #
-# Copyright (C) 2012-2021 Internet Archive
+# Copyright (C) 2012-2022 Internet Archive
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -23,7 +23,7 @@ internetarchive.utils
 
 This module provides utility functions for the internetarchive library.
 
-:copyright: (C) 2012-2021 by Internet Archive.
+:copyright: (C) 2012-2022 by Internet Archive.
 :license: AGPL 3, see LICENSE for more details.
 """
 import hashlib

--- a/internetarchive/utils.py
+++ b/internetarchive/utils.py
@@ -361,7 +361,7 @@ def is_valid_metadata_key(name):
     # are way more restrictive and only allow ".-A-Za-z_", possibly followed
     # by an index in square brackets e. g. [0].
     # On the other hand the Archive allows tags starting with the string "xml".
-    return bool(re.match(r'^[A-Za-z][.\-0-9A-Za-z_]+(?:\[[0-9]+\])?$', name))
+    return bool(re.fullmatch(r'[A-Za-z][.\-0-9A-Za-z_]+(?:\[[0-9]+\])?', name))
 
 
 def merge_dictionaries(dict0, dict1, keys_to_drop=None):


### PR DESCRIPTION
Change back to using `re.fullmatch` instead of an equivalently anchored `re.match`, to be more idiomatic.