### PR TITLE
Fix `Item.upload_file` accidentally passing the S3 access key as the item identifier for the S3 overload check

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -25,6 +25,7 @@ Unreleased
 - Fixed uploading from a spreadsheet not reusing the ``identifier`` column.
 - Fixed uploading from a spreadsheet not correctly dropping the ``item`` column from metadata.
 - Fixed uploading from a spreadsheet with ``--checksum`` crashing on skipped files.
+- Fixed minor bug in S3 overload check on upload error retries.
 
 2.3.0 (2022-01-20)
 ++++++++++++++++++

--- a/internetarchive/item.py
+++ b/internetarchive/item.py
@@ -1039,7 +1039,7 @@ class Item(BaseItem):
                                  f'{retries_sleep} seconds and retrying. '
                                  f'{retries} retries left.')
                     if retries > 0:
-                        if self.session.s3_is_overloaded(access_key):
+                        if self.session.s3_is_overloaded(access_key=access_key):
                             sleep(retries_sleep)
                             log.info(error_msg)
                             if verbose:


### PR DESCRIPTION
The first argument of `s3_is_overloaded` is the item identifier, not the access key. As far as I can tell, this is a minor bug without significant impact.