### PR TITLE
Drop support for Python 3.6

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.6', '3.7', '3.8', '3.9', '3.10', 'pypy-3.7', 'pypy-3.8']
+        python: ['3.7', '3.8', '3.9', '3.10', 'pypy-3.7', 'pypy-3.8']
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,7 +8,7 @@ Unreleased
 
 **Breaking changes**
 
-- Removed Python 2.7 and 3.5 support
+- Removed Python 2.7, 3.5, and 3.6 support
 
 **Features and Improvements**
 

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
             'ia = internetarchive.cli.ia:main',
         ],
     },
-    python_requires='>=3.6',
+    python_requires='>=3.7',
     install_requires=[
         'docopt>=0.6.0,<0.7.0',
         'jsonpatch>=0.4',
@@ -52,7 +52,6 @@ setup(
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3 :: Only',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',

--- a/tox.ini
+++ b/tox.ini
@@ -1,14 +1,11 @@
 [tox]
-envlist = py36,py37,py38,py39,py310,pypy37,pypy38
+envlist = py37,py38,py39,py310,pypy37,pypy38
 
 [testenv]
 deps = -r tests/requirements.txt
 # See setup.cfg for changes to default settings
 commands = flake8
            pytest {posargs}
-
-[testenv:py36]
-basepython=python3.6
 
 [testenv:py37]
 basepython=python3.7


### PR DESCRIPTION
I'm suggesting to drop Python 3.6 support. It has reached EOL. Direct dependencies have announced that they will drop support soon (Requests) or have already removed it in the dev version (urllib3 and pytest). And last but not least, I'd like to use a convenient feature added in 3.7 (`contextlib.nullcontext`) in an upcoming PR for #280.