### PR TITLE
Fix single-backticked literals in HISTORY.rst

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -24,7 +24,7 @@ Unreleased
 **Bugfixes**
 
 - Fixed treatment of list-like file metadata in ``ia list`` under Python 3
-- Fixed `ia upload --debug` only displaying the first request.
+- Fixed ``ia upload --debug`` only displaying the first request.
 - Fixed uploading from stdin crashing with UnicodeDecodeError or TypeError exception.
 - Fixed ``ia upload`` silently ignoring exceptions.
 - Fixed uploading from a spreadsheet with a BOM (UTF-8 byte-order mark) raising a KeyError.
@@ -218,7 +218,7 @@ Unreleased
 
 **Bugfixes**
 
-- ``ia download`` now displays `download failed` instead of `success` when download fails.
+- ``ia download`` now displays ``download failed`` instead of ``success`` when download fails.
 - Fixed bug where ``Item.get_file`` would not work on unicode names in Python 2.
 
 1.8.5 (2019-06-07)
@@ -597,8 +597,8 @@ Unreleased
 
 **Bugfixes**
 
-- Fixed memory leak in `ia upload --spreadsheet=metadata.csv`.
-- Fixed arg parsing bug in `ia` CLI.
+- Fixed memory leak in ``ia upload --spreadsheet=metadata.csv``.
+- Fixed arg parsing bug in ``ia`` CLI.
 
 1.0.0 (2016-03-01)
 ++++++++++++++++++
@@ -627,26 +627,26 @@ Unreleased
 
 **Bugfixes**
 
-- Fixed `ia help` bug.
-- Fixed bug in `File.download()` where connection errors weren't being caught/retried correctly.
+- Fixed ``ia help`` bug.
+- Fixed bug in ``File.download()`` where connection errors weren't being caught/retried correctly.
 
 0.9.7 (2015-11-05)
 ++++++++++++++++++
 
 **Bugfixes**
 
-- Cleanup partially downloaded files when `download()` fails.
+- Cleanup partially downloaded files when ``download()`` fails.
 
 **Features and Improvements**
 
-- Added `--format` option to `ia delete`.
-- Refactored `download()` and `ia download` to behave more like rsync. Files are now clobbered by default,
-  `ignore_existing` and `--ignore-existing` now skip over files already downloaded without making a request.
-- Added retry support to `download()` and `ia download`.
-- Added `files` kwarg to `Item.download()` for downloading specific files.
-- Added `ignore_errors` option to `File.download()` for ignoring (but logging) exceptions.
+- Added ``--format`` option to ``ia delete``.
+- Refactored ``download()`` and ``ia download`` to behave more like rsync. Files are now clobbered by default,
+  ``ignore_existing`` and ``--ignore-existing`` now skip over files already downloaded without making a request.
+- Added retry support to ``download()`` and ``ia download``.
+- Added ``files`` kwarg to ``Item.download()`` for downloading specific files.
+- Added ``ignore_errors`` option to ``File.download()`` for ignoring (but logging) exceptions.
 - Added default timeouts to metadata and download requests.
-- Less verbose output in `ia download` by default, use `ia download --verbose` for old style output.
+- Less verbose output in ``ia download`` by default, use ``ia download --verbose`` for old style output.
 
 0.9.6 (2015-10-12)
 ++++++++++++++++++
@@ -660,14 +660,14 @@ Unreleased
 
 **Features and Improvements**
 
-- Added skip based on mtime and length if no other clobber/skip options specified in `download()` and `ia download`.
+- Added skip based on mtime and length if no other clobber/skip options specified in ``download()`` and ``ia download``.
 
 0.9.4 (2015-10-01)
 ++++++++++++++++++
 
 **Features and Improvements**
 
-- Added `internetarchive.api.get_username()` for retrieving a username with an S3 key-pair.
+- Added ``internetarchive.api.get_username()`` for retrieving a username with an S3 key-pair.
 - Added ability to sync downloads via an sqlite database.
 
 0.9.3 (2015-09-28)
@@ -675,12 +675,12 @@ Unreleased
 
 **Features and Improvements**
 
-- Added ability to download items from an itemlist or search query in `ia download`.
-- Made `ia configure` Python 3 compatible.
+- Added ability to download items from an itemlist or search query in ``ia download``.
+- Made ``ia configure`` Python 3 compatible.
 
 **Bugfixes**
 
-- Fixed bug in `ia upload` where uploading an item with more than one collection specified caused the collection check to fail.
+- Fixed bug in ``ia upload`` where uploading an item with more than one collection specified caused the collection check to fail.
 
 
 0.9.2 (2015-08-17)
@@ -688,7 +688,7 @@ Unreleased
 
 **Bugfixes**
 
-- Added error message for failed `ia configure` calls due to invalid creds. 
+- Added error message for failed ``ia configure`` calls due to invalid creds. 
 
 
 0.9.1 (2015-08-13)
@@ -697,7 +697,7 @@ Unreleased
 **Bugfixes**
 
 - Updated docopt to v0.6.2 and PyYAML to v3.11.
-- Updated setup.py to automatically pull version from `__init__`.
+- Updated setup.py to automatically pull version from ``__init__``.
 
 
 0.8.5 (2015-07-13)
@@ -705,7 +705,7 @@ Unreleased
 
 **Bugfixes**
 
-- Fixed UnicodeEncodeError in `ia metadata --append`.
+- Fixed UnicodeEncodeError in ``ia metadata --append``.
 
 **Features and Improvements**
 
@@ -717,7 +717,7 @@ Unreleased
 
 **Features and Improvements**
 
-- Added check to `ia upload` to see if the collection being uploaded to exists.
+- Added check to ``ia upload`` to see if the collection being uploaded to exists.
   Also added an option to override this check.
 
 0.8.3 (2015-05-18)
@@ -740,31 +740,31 @@ Unreleased
 
 **Bugfixes**
 
-- Fixed bug in `internetarchive.config.get_auth_config` (i.e. `ia configure`)
+- Fixed bug in ``internetarchive.config.get_auth_config`` (i.e. ``ia configure``)
   where logged-in cookies returned expired within hours. Cookies should now be
   valid for about one year.
 
 0.7.8 (2014-12-23)
 ++++++++++++++++++
 
-- Output error message when downloading non-existing files in `ia download` rather
+- Output error message when downloading non-existing files in ``ia download`` rather
   than raising Python exception.
-- Fixed IOError in `ia search` when using `head`, `tail`, etc..
-- Simplified `ia search` to output only JSON, rather than doing any special
+- Fixed IOError in ``ia search`` when using ``head``, ``tail``, etc..
+- Simplified ``ia search`` to output only JSON, rather than doing any special
   formatting.
-- Added experimental support for creating pex binaries of ia in `Makefile`. 
+- Added experimental support for creating pex binaries of ia in ``Makefile``. 
 
 0.7.7 (2014-12-17)
 ++++++++++++++++++
 
-- Simplified `ia configure`. It now only asks for Archive.org email/password and
+- Simplified ``ia configure``. It now only asks for Archive.org email/password and
   automatically adds S3 keys and Archive.org cookies to config.
-  See `internetarchive.config.get_auth_config()`.
+  See ``internetarchive.config.get_auth_config()``.
 
 0.7.6 (2014-12-17)
 ++++++++++++++++++
 
-- Write metadata to stdout rather than stderr in `ia mine`.
+- Write metadata to stdout rather than stderr in ``ia mine``.
 - Added options to search archive.org/v2.
 - Added destdir option to download files/itemdirs to a given destination dir.
 
@@ -776,39 +776,39 @@ Unreleased
 0.7.4 (2014-10-08)
 ++++++++++++++++++
 
-- Fixed missing "import" typo in `internetarchive.iacli.ia_upload`.
+- Fixed missing "import" typo in ``internetarchive.iacli.ia_upload``.
 
 0.7.3 (2014-10-08)
 ++++++++++++++++++
 
-- Added progress bar to `ia mine`.
-- Fixed unicode metadata support for `upload()`.
+- Added progress bar to ``ia mine``.
+- Fixed unicode metadata support for ``upload()``.
 
 0.7.2 (2014-09-16)
 ++++++++++++++++++
 
-- Suppress `KeyboardInterrupt` exceptions and exit with status code 130.
-- Added ability to skip downloading files based on checksum in `ia download`,
-  `Item.download()`, and `File.download()`.
-- `ia download` is now verbose by default. Output can be suppressed with the `--quiet`
+- Suppress ``KeyboardInterrupt`` exceptions and exit with status code 130.
+- Added ability to skip downloading files based on checksum in ``ia download``,
+  ``Item.download()``, and ``File.download()``.
+- ``ia download`` is now verbose by default. Output can be suppressed with the ``--quiet``
   flag.
 - Added an option to not download into item directories, but rather the current working
-  directory (i.e. `ia download --no-directories <id>`).
+  directory (i.e. ``ia download --no-directories <id>``).
 - Added/fixed support for modifying different metadata targets (i.e. files/logo.jpg).
 
 0.7.1 (2014-08-25)
 ++++++++++++++++++
 
-- Added `Item.s3_is_overloaded()` method for S3 status check. This method is now used on
+- Added ``Item.s3_is_overloaded()`` method for S3 status check. This method is now used on
   retries in the upload method now as well. This will avoid uploading any data if a 503
   is expected. If a 503 is still returned, retries are attempted.
-- Added `--status-check` option to `ia upload` for S3 status check.
-- Added `--source` parameter to `ia list` for returning files matching IA source (i.e. 
+- Added ``--status-check`` option to ``ia upload`` for S3 status check.
+- Added ``--source`` parameter to ``ia list`` for returning files matching IA source (i.e. 
   original, derivative, metadata, etc.).
-- Added support to `ia upload` for setting remote-name if only a single file is being
+- Added support to ``ia upload`` for setting remote-name if only a single file is being
   uploaded.
 - Derive tasks are now only queued after the last file has been uploaded.
-- File URLs are now quoted in `File` objects, for downloading files with special
+- File URLs are now quoted in ``File`` objects, for downloading files with special
   characters in their filenames
 
 0.7.0 (2014-07-23)
@@ -820,13 +820,13 @@ Unreleased
 ++++++++++++++++++
 
 - Added support for \n and \r characters in upload headers.
-- Added support for reading filenames from stdin when using the `ia delete` command.
+- Added support for reading filenames from stdin when using the ``ia delete`` command.
 
 0.6.8 (2014-07-11)
 ++++++++++++++++++
 
-- The delete `ia` subcommand is now verbose by default.
-- Added glob support to the delete `ia` subcommand (i.e. `ia delete --glob='*jpg'`).
+- The delete ``ia`` subcommand is now verbose by default.
+- Added glob support to the delete ``ia`` subcommand (i.e. ``ia delete --glob='*jpg'``).
 - Changed indexed metadata elements to clobber values instead of insert.
 - AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY are now deprecated.
   IAS3_ACCESS_KEY and IAS3_SECRET_KEY must be used if setting IAS3


### PR DESCRIPTION
Literals (= fixed-space `foobar`) use double backticks in rST as single backticks have special meaning (e.g. links).