### PR TITLE
pre-commit: Add mypy checking of Python type hints

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -62,15 +62,15 @@ repos:
   #      args:
   #        - --profile black
 
-  #- repo: https://github.com/pre-commit/mirrors-mypy
-  #  rev: 'v0.942'
-  #  hooks:
-  #    - id: mypy
-  #      args:
-  #        - --ignore-missing-imports
-  #        - --scripts-are-modules
-  #      additional_dependencies:
-  #        - types-all
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: 'v0.950'
+    hooks:
+      - id: mypy
+        args:
+          - --ignore-missing-imports
+          - --scripts-are-modules
+        additional_dependencies:
+          - types-all
 
   #- repo: https://github.com/asottile/pyupgrade
   #  rev: v2.32.0

--- a/internetarchive/cli/ia.py
+++ b/internetarchive/cli/ia.py
@@ -62,7 +62,7 @@ import errno
 import os
 import sys
 
-from docopt import docopt, printable_usage
+from docopt import docopt, printable_usage  # type: ignore
 from pkg_resources import DistributionNotFound, iter_entry_points
 from schema import Or, Schema, SchemaError
 

--- a/internetarchive/cli/ia_copy.py
+++ b/internetarchive/cli/ia_copy.py
@@ -39,7 +39,7 @@ options:
 import sys
 from urllib.parse import quote
 
-from docopt import docopt, printable_usage
+from docopt import docopt, printable_usage  # type: ignore
 from schema import And, Or, Schema, SchemaError, Use
 
 import internetarchive as ia

--- a/internetarchive/cli/ia_delete.py
+++ b/internetarchive/cli/ia_delete.py
@@ -47,7 +47,7 @@ options:
 import sys
 
 import requests.exceptions
-from docopt import docopt, printable_usage
+from docopt import docopt, printable_usage  # type: ignore
 from schema import And, Or, Schema, SchemaError, Use
 
 from internetarchive.cli.argparser import convert_str_list_to_unicode, get_args_dict

--- a/internetarchive/cli/ia_download.py
+++ b/internetarchive/cli/ia_download.py
@@ -65,7 +65,7 @@ import os
 import sys
 from os.path import exists as dir_exists
 
-from docopt import docopt, printable_usage
+from docopt import docopt, printable_usage  # type: ignore
 from schema import And, Or, Schema, SchemaError, Use
 
 from internetarchive.cli.argparser import get_args_dict

--- a/internetarchive/cli/ia_metadata.py
+++ b/internetarchive/cli/ia_metadata.py
@@ -54,7 +54,7 @@ import sys
 from collections import defaultdict
 from copy import copy
 
-from docopt import docopt, printable_usage
+from docopt import docopt, printable_usage  # type: ignore
 from schema import And, Or, Schema, SchemaError, Use
 
 from internetarchive.cli.argparser import (

--- a/internetarchive/cli/ia_move.py
+++ b/internetarchive/cli/ia_move.py
@@ -35,7 +35,7 @@ options:
 """
 import sys
 
-from docopt import docopt, printable_usage
+from docopt import docopt, printable_usage  # type: ignore
 from schema import And, Or, Schema, SchemaError, Use
 
 from internetarchive.cli import ia_copy

--- a/internetarchive/cli/ia_search.py
+++ b/internetarchive/cli/ia_search.py
@@ -45,7 +45,7 @@ examples:
 import sys
 from itertools import chain
 
-from docopt import docopt, printable_usage
+from docopt import docopt, printable_usage  # type: ignore
 from requests.exceptions import ConnectTimeout, ReadTimeout
 from schema import And, Or, Schema, SchemaError, Use
 

--- a/internetarchive/cli/ia_upload.py
+++ b/internetarchive/cli/ia_upload.py
@@ -70,7 +70,7 @@ from copy import deepcopy
 from locale import getpreferredencoding
 from tempfile import TemporaryFile
 
-from docopt import docopt, printable_usage
+from docopt import docopt, printable_usage  # type: ignore
 from requests.exceptions import HTTPError
 from schema import And, Or, Schema, SchemaError, Use
 

--- a/internetarchive/session.py
+++ b/internetarchive/session.py
@@ -145,7 +145,7 @@ class ArchiveSession(requests.sessions.Session):
         """Generate a User-Agent string to be sent with every request."""
         uname = platform.uname()
         try:
-            lang = locale.getlocale()[0][:2]
+            lang = locale.getlocale()[0][:2]  # type: ignore
         except Exception:
             lang = ''
         py_version = '{0}.{1}.{2}'.format(*sys.version_info)
@@ -257,7 +257,7 @@ class ArchiveSession(requests.sessions.Session):
         request_kwargs = request_kwargs or {}
         if not item_metadata:
             logger.debug(f'no metadata provided for "{identifier}", retrieving now.')
-            item_metadata = self.get_metadata(identifier, request_kwargs)
+            item_metadata = self.get_metadata(identifier, request_kwargs) or {}
         mediatype = item_metadata.get('metadata', {}).get('mediatype')
         try:
             item_class = self.ITEM_MEDIATYPE_TABLE.get(mediatype, Item)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -132,6 +132,7 @@ def nasa_metadata():
     return json.loads(load_test_data_file('metadata/nasa.json'))
 
 
-@pytest.fixture
+# TODO: Why is this function defined twice in this file?  See issue #505
+@pytest.fixture  # type: ignore
 def nasa_item(nasa_mocker):
     return get_item('nasa')


### PR DESCRIPTION
Add [`mypy`](http://mypy-lang.org) static type checking to our pre-commit hooks.
* The `printable_usage` is inexplicable to me but was mentioned before in #236 if someone can find a root cause.
* The duplicate definition of `nasa_item()` is discussed in #505 if someone can propose the right solution.