### PR TITLE
Pre-commit: Add black code formatting only on changed lines

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,14 +36,14 @@ repos:
         args:
           - --skip=B101,B103,B105,B106,B303,B324,B318,B404,B408,B602
 
-  #- repo: https://github.com/psf/black
-  #  rev: 22.3.0
-  #  hooks:
-  #    - id: black
-  #      language_version: python3  # Should be a command that runs python3.6+
-  #      args:
-  #      - --diff
-  #      - --skip-string-normalization
+  - repo: https://github.com/psf/black
+    rev: 22.3.0
+    hooks:
+      - id: black
+        language_version: python3  # Should be a command that runs python3.6+
+        args:
+        - --diff
+        - --skip-string-normalization
 
   - repo: https://github.com/codespell-project/codespell
     rev: v2.1.0
@@ -51,7 +51,7 @@ repos:
       - id: codespell  # See setup.cfg for args
 
   - repo: https://gitlab.com/pycqa/flake8
-    rev: 4.0.1
+    rev: 3.9.2
     hooks:
       - id: flake8
         additional_dependencies: [flake8-2020, flake8-comprehensions]  # TODO: flake8-bugbear
@@ -64,7 +64,7 @@ repos:
           - --profile black
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: 'v0.950'
+    rev: v0.950
     hooks:
       - id: mypy
         args:


### PR DESCRIPTION
This pre-commit hook with run [`black`](ttps://github.com/psf/black) code formatting with `--skip-string-normalization` (do not prefer double quotes over single quotes) only on those lines of Python that are modified.

To blacken the entire codebase, remove the `--diff` and then do `pre-commit run --all-files`