### PR TITLE
Update docs based on Python type hints

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
-alabaster==0.7.6
-docutils==0.12
-Sphinx==1.2.2
+alabaster==0.7.12
+docutils==0.18.1
+Sphinx==4.5.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
 alabaster==0.7.12
-docutils==0.18.1
+docutils<0.18
 Sphinx==4.5.0
+sphinx-autodoc-typehints==1.18.1

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -40,6 +40,7 @@ extensions = [
     'sphinx.ext.viewcode',
     'sphinx.ext.intersphinx',
     'alabaster',
+    'sphinx_autodoc_typehints',
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/internetarchive/api.py
+++ b/internetarchive/api.py
@@ -49,17 +49,16 @@ def get_session(
     object is the main interface to the ``internetarchive`` lib. It allows you to
     persist certain parameters across tasks.
 
-    :type config: dict
-    :param config: (optional) A dictionary used to configure your session.
+    :param config: A dictionary used to configure your session.
 
-    :type config_file: str
-    :param config_file: (optional) A path to a config file used to configure your session.
+    :param config_file: A path to a config file used to configure your session.
 
-    :type http_adapter_kwargs: dict
-    :param http_adapter_kwargs: (optional) Keyword arguments that
+    :param debug: To be passed on to this session's method calls.
+
+    :param http_adapter_kwargs: Keyword arguments that
                                 :py:class:`requests.adapters.HTTPAdapter` takes.
 
-    :returns: :class:`ArchiveSession` object.
+    :returns: To persist certain parameters across tasks.
 
     Usage:
 

--- a/internetarchive/utils.py
+++ b/internetarchive/utils.py
@@ -382,16 +382,12 @@ def merge_dictionaries(
        If equal keys exist in both dictionaries,
        entries in`dict0` are overwritten.
 
-       :type dict0: dict
        :param dict0: A base dictionary with the bulk of the items.
 
-       :type dict1: dict
        :param dict1: Additional items which overwrite the items in `dict0`.
 
-       :type keys_to_drop: iterable
        :param keys_to_drop: An iterable of keys to drop from `dict0` before the merge.
 
-       :rtype: dict
        :returns: A merged dictionary.
        """
     new_dict = dict0.copy()


### PR DESCRIPTION
It was quite easy to add https://pypi.org/project/sphinx-autodoc-typehints to `docs/requirements.txt` and then generate docs based on Python type hints that look like this:

<img width="696" alt="Screenshot 2022-05-11 at 07 30 29" src="https://user-images.githubusercontent.com/3709715/167776356-f188f8f3-4583-4271-aa30-004abb3ebfd6.png">

---

This enables us to remove a fair amount of repetitive (and somewhat erroneous) typing information from method docstrings.  These lines can all be remove from docstrings: `grep ":type " **/*.py` and `grep ":rtype:" **/*.py`

@JustAnotherArchivist @maxz ... Might be of interest.
