### PR TITLE
lint_python: Make mypy a mandatory test

### DIFF
--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -7,15 +7,10 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v3
       - run: pip install --upgrade pip wheel
-      - run: pip install black flake8 flake8-2020 flake8-bugbear
-                         flake8-comprehensions mypy pytest pyupgrade safety
+      - run: pip install black flake8 flake8-2020 flake8-comprehensions
+                         mypy pyupgrade safety
       - run: black --check . || true
-      - run: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-      - run: flake8 . --count --exit-zero --max-complexity=10 --max-line-length=88
-                      --show-source --statistics
+      - run: flake8 .  # See setup.cfg for configuration
       - run: pip install -r pex-requirements.txt -r tests/requirements.txt
-      - run: mkdir --parents --verbose .mypy_cache
-      - run: mypy --ignore-missing-imports --install-types --non-interactive . || true
-      - run: pytest . || true
-      - run: pytest --doctest-modules . || true
+      - run: mypy --non-interactive .  # See setup.cfg for configuration
       - run: safety check

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,3 +12,11 @@ per-file-ignores =
     ./tests/test_api.py: E712
 show-source = true
 statistics = true
+
+[mypy]
+ignore_missing_imports = True
+install_types = True
+pretty = True
+scripts_are_modules = True
+show_error_codes = True
+show_error_context = True


### PR DESCRIPTION
Remove the `|| test` training wheels from mypy and move its config to setup.cfg with codespell and flake8.

Remove pytest because that is covered by the `tox` tests.