### PR TITLE
GitHub Action to install ia with and without tqdm

### DIFF
--- a/.github/workflows/install_internetarchive.yml
+++ b/.github/workflows/install_internetarchive.yml
@@ -1,0 +1,14 @@
+name: install_internetarchive
+on:
+  pull_request:
+  push:
+jobs:
+  install_internetarchive:
+    runs-on: ubuntu-latest
+    steps:
+      - run: pip install internetarchive
+  install_tqdm_and_then_internetarchive:
+    runs-on: ubuntu-latest
+    steps:
+      - run: pip install tqdm  # This line is REQUIRED
+      - run: pip install internetarchive


### PR DESCRIPTION
Proof that `tqdm` MUST be installed before `internetarchive`

@eggplants Was there any change #527 that could cause pip to not recognize that `tqdm` is a pre-requisite for `internetarchive`?