### PR TITLE
upload: Expand a period to the contents of the current directory.

### DIFF
--- a/internetarchive/cli/ia_upload.py
+++ b/internetarchive/cli/ia_upload.py
@@ -237,6 +237,9 @@ def main(argv, session):
             local_file.seek(0)
         else:
             local_file = args['<file>']
+            # Properly expand a period to the contents of the current working directory.
+            if local_file and local_file[0] == '.':
+                local_file = os.listdir('.')
 
         if isinstance(local_file, (list, tuple, set)) and args['--remote-name']:
             local_file = local_file[0]

--- a/internetarchive/cli/ia_upload.py
+++ b/internetarchive/cli/ia_upload.py
@@ -238,8 +238,9 @@ def main(argv, session):
         else:
             local_file = args['<file>']
             # Properly expand a period to the contents of the current working directory.
-            if local_file and local_file[0] == '.':
-                local_file = os.listdir('.')
+            if '.' in local_file:
+                local_file = [p for p in local_file if p != '.']
+                local_file = os.listdir('.') + local_file
 
         if isinstance(local_file, (list, tuple, set)) and args['--remote-name']:
             local_file = local_file[0]

--- a/internetarchive/cli/ia_upload.py
+++ b/internetarchive/cli/ia_upload.py
@@ -114,7 +114,7 @@ def _upload_files(item, files, upload_kwargs, prev_identifier=None, archive_sess
     return responses
 
 
-def main(argv, session):
+def main(argv, session):  # noqa: C901
     args = docopt(__doc__, argv=argv)
     ERRORS = False
 

--- a/internetarchive/session.py
+++ b/internetarchive/session.py
@@ -121,7 +121,7 @@ class ArchiveSession(requests.sessions.Session):
         self.secret_key: str = self.config.get('s3', {}).get('secret')
         self.http_adapter_kwargs: MutableMapping = http_adapter_kwargs or {}
 
-        self.headers = default_headers()
+        self.headers = default_headers()  # type: ignore[assignment]
         self.headers.update({'User-Agent': self._get_user_agent_string()})
         self.headers.update({'Connection': 'close'})
 


### PR DESCRIPTION
The previous behavior when specifying a period as a wildcard was faulty.
Now a period is properly expanded to the contents of the current directory.

ia_upload.py seemed to be the most sensible location for this fix, since it
is the closest to receiving the path and so that the behavior of the library
does not change.

Closes #220, fixes #535.