### PR TITLE
host could be same as in get_auth_config

### DIFF
--- a/internetarchive/api.py
+++ b/internetarchive/api.py
@@ -528,7 +528,7 @@ def configure(  # nosec: hardcoded_password_default
     username: str = "",
     password: str = "",
     config_file: str = "",
-    host: str = "",
+    host: str = "archive.org",
 ) -> str:
     """Configure internetarchive with your Archive.org credentials.
 


### PR DESCRIPTION
Raises a weird invalid host error without default arg