### PR TITLE
Fixes memoryview error when running `Item.upload` with `StringIO` input and `verbose=True`

### DIFF
--- a/internetarchive/item.py
+++ b/internetarchive/item.py
@@ -954,10 +954,10 @@ class Item(BaseItem):
                     expected_size = math.ceil(size / chunk_size)
                     chunks = chunk_generator(body, chunk_size)
                     progress_generator = tqdm(chunks,
-                                          desc=f' uploading {key}',
-                                          dynamic_ncols=True,
-                                          total=expected_size,
-                                          unit='MiB')
+                                              desc=f' uploading {key}',
+                                              dynamic_ncols=True,
+                                              total=expected_size,
+                                              unit='MiB')
                     data = None
                     # pre_encode is needed because http doesn't know that it
                     # needs to encode a TextIO object when it's wrapped

--- a/internetarchive/session.py
+++ b/internetarchive/session.py
@@ -121,7 +121,8 @@ class ArchiveSession(requests.sessions.Session):
         self.secret_key: str = self.config.get('s3', {}).get('secret')
         self.http_adapter_kwargs: MutableMapping = http_adapter_kwargs or {}
 
-        self.headers = default_headers()
+        # mypy doesn't like 'headers: Dict[Union[bytes, str]] = Dict[str]'
+        self.headers = default_headers()  # type: ignore
         self.headers.update({'User-Agent': self._get_user_agent_string()})
         self.headers.update({'Connection': 'close'})
 

--- a/internetarchive/utils.py
+++ b/internetarchive/utils.py
@@ -134,11 +134,18 @@ def suppress_keyboard_interrupt_message() -> None:
 
 
 class IterableToFileAdapter:
-    def __init__(self, iterable, size: int):
+    def __init__(self, iterable, size: int, pre_encode: bool = False):
         self.iterator = iter(iterable)
         self.length = size
+        # pre_encode is needed because http doesn't know that it
+        # needs to encode a TextIO object when it's wrapped
+        # in the Iterator from tqdm.
+        # So, this FileAdapter provides pre-encoded output
+        self.pre_encode = pre_encode
 
     def read(self, size: int = -1):  # TBD: add buffer for `len(data) > size` case
+        if self.pre_encode:
+            return next(self.iterator, '').encode("iso-8859-1")
         return next(self.iterator, b'')
 
     def __len__(self) -> int:

--- a/internetarchive/utils.py
+++ b/internetarchive/utils.py
@@ -145,6 +145,11 @@ class IterableToFileAdapter:
 
     def read(self, size: int = -1):  # TBD: add buffer for `len(data) > size` case
         if self.pre_encode:
+            # this adapter is intended to emulate the encoding that is usually
+            # done by the http lib.
+            # As of 2022, iso-8859-1 encoding is used to meet the HTTP standard,
+            # see in the cpython repo (https://github.com/python/cpython
+            # Lib/http/client.py lines 246; 1340; or grep 'iso-8859-1'
             return next(self.iterator, '').encode("iso-8859-1")
         return next(self.iterator, b'')
 


### PR DESCRIPTION
## The Bug
When running, for example:
```python
import io
import internetarchive as ia

ia.upload("ia_bug_test", {"test.txt": StringIO("test")}, access_key="", secret_key="", verbose=True)
```
instead of the expected message:
```
 uploading test.txt: 100%|███████████████████████████████████████████████████| 1/1 [00:00<00:00, 10.30MiB/s]
 ```
the Python output is a long error ending in:
 ```python
 TypeError: memoryview: a bytes-like object is required, not 'str'
```
(the entire error is pasted at the end of this message). This only occurs when the input is a `StringIO` object and `verbose=True`.

This error **is not reproducible in the test suite** because it depends on an interaction between `internetarchive` and the internals of `http`. `http` checks to see if body input is a `TextIOBase` object. If it is a `TextIOBase`, `http` encodes the string output of the `TextIOBase` into bytes. However, only when `verbose=True`, `internetarchive` wraps the `TextIOBase` in a `tqdm` iterable and then `IterableToFileAdapter`, which hides the information that, internally, the data from this object is from a `TextIOBase`. This causes `http`'s check to return `False`, so `http` does not encode the strings into bytes, which eventually causes this memoryview error.

## The Fix
The proposed fix to this issue makes a small modification to `IterableToFileAdapter` which automatically `encode`s data as it is read out. The `pre_encode` flag is set to enable this feature when we observe a `TextIOBase`, but it could be expanded to other situations where we have an input that `http` won't recognize and encode for us.


## Appendix
```
 uploading test.txt:   0%|                                                           | 0/1 [00:00<?, ?MiB/s]Traceback (most recent call last):
  File "/home/varun/harvard-lil/internetarchive/internetarchive/session.py", line 540, in send
    reraise_modify(e, e.request.url, prepend=False)  # type: ignore
AttributeError: 'TypeError' object has no attribute 'request'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/varun/harvard-lil/internetarchive/../perma/ia_test.py", line 7, in <module>
    internetarchive.upload("perma_cc_mvarun_bulktest", {"test.txt": StringIO("test")}, access_key=ACCESS, secret_key=SECRET, verbose=True)
  File "/home/varun/harvard-lil/internetarchive/internetarchive/api.py", line 277, in upload
    return item.upload(
  File "/home/varun/harvard-lil/internetarchive/internetarchive/item.py", line 1190, in upload
    resp = self.upload_file(body,
  File "/home/varun/harvard-lil/internetarchive/internetarchive/item.py", line 1006, in upload_file
    response = self.session.send(prepared_request,
  File "/home/varun/harvard-lil/internetarchive/internetarchive/session.py", line 543, in send
    raise e
  File "/home/varun/harvard-lil/internetarchive/internetarchive/session.py", line 537, in send
    r = super().send(request, **kwargs)
  File "/home/varun/harvard-lil/internetarchive/lib/python3.10/site-packages/requests/sessions.py", line 701, in send
    r = adapter.send(request, **kwargs)
  File "/home/varun/harvard-lil/internetarchive/lib/python3.10/site-packages/requests/adapters.py", line 489, in send
    resp = conn.urlopen(
  File "/home/varun/harvard-lil/internetarchive/lib/python3.10/site-packages/urllib3/connectionpool.py", line 703, in urlopen
    httplib_response = self._make_request(
  File "/home/varun/harvard-lil/internetarchive/lib/python3.10/site-packages/urllib3/connectionpool.py", line 398, in _make_request
    conn.request(method, url, **httplib_request_kw)
  File "/home/varun/harvard-lil/internetarchive/lib/python3.10/site-packages/urllib3/connection.py", line 239, in request
    super(HTTPConnection, self).request(method, url, body=body, headers=headers)
  File "/usr/lib/python3.10/http/client.py", line 1282, in request
    self._send_request(method, url, body, headers, encode_chunked)
  File "/usr/lib/python3.10/http/client.py", line 1328, in _send_request
    self.endheaders(body, encode_chunked=encode_chunked)
  File "/usr/lib/python3.10/http/client.py", line 1277, in endheaders
    self._send_output(message_body, encode_chunked=encode_chunked)
  File "/usr/lib/python3.10/http/client.py", line 1076, in _send_output
    self.send(chunk)
  File "/usr/lib/python3.10/http/client.py", line 1002, in send
    self.sock.sendall(d)
  File "/usr/lib/python3.10/ssl.py", line 1234, in sendall
    with memoryview(data) as view, view.cast("B") as byte_view:
TypeError: memoryview: a bytes-like object is required, not 'str'
```
