### PR TITLE
Retry search at current cursor on total:None

### DIFF
--- a/internetarchive/search.py
+++ b/internetarchive/search.py
@@ -150,6 +150,11 @@ class Search:
             j = r.json()
             if j.get('error'):
                 yield j
+            if j['total'] is None:
+                # print('UNEXPECTED RESPONSE:', j)
+                # Unexpected empty response when iterating on cursor
+                # Retry with same cursor:
+                continue
             num_found = int(j['total'])
             if not self._num_found:
                 self._num_found = num_found


### PR DESCRIPTION
This is more of a workaround for an issue I've run into on search paging results. I'm not why the client is sporadically receiving an unexpected response -- it seems like a problem with the search API which might need investigation.

Getting the following error occasionally on `ia search` with largish result sets (eg: 92669) part way through:

```
Traceback (most recent call last):
  File "/home/charles/.local/bin/ia", line 8, in <module>
    sys.exit(main())
  File "/home/charles/.local/lib/python3.8/site-packages/internetarchive/cli/ia.py", line 171, in main
    sys.exit(ia_module.main(argv, session))
  File "/home/charles/.local/lib/python3.8/site-packages/internetarchive/cli/ia_search.py", line 100, in main
    for result in search:
  File "/home/charles/.local/lib/python3.8/site-packages/internetarchive/search.py", line 279, in __next__
    return self.iterator.__next__()
  File "/home/charles/.local/lib/python3.8/site-packages/internetarchive/search.py", line 153, in _scrape
    num_found = int(j['total'])
TypeError: int() argument must be a string, a bytes-like object or a number, not 'NoneType'
```

Example API JSON response (from adding some debug code to capture the unexpected response):

```
UNEXPECTED RESPONSE: {'items': [], 'count': 0, 'previous': 'W3siaWRlbn....REDACTEDjustincase...X0tONjgzIn1d', 'total': None}
```

This was occurring sporadically for me over the weekend at 10K multiples on various queries from 30K to 90K `num_results`.

The query I was using is admittedly a bit complex:

`ia search "mediatype:texts AND boxid:IA* AND scribe3_search_catalog:isbn AND identifier:t*" -f "scribe3_search_id" -p scope:all` 

But I have in the past run 'worse' ones with more clauses, fields, and expected results without problems :)

I haven't tested yet whether the `scope:all` contributes to the buggy behaviour. I started filtering on identifier first letter to reduce the size of the queries. 

The code change here simply checks `total` before assuming it is an `int`, and retries the 10K limit request at the current cursor if `total` is `None` -- which seems an unexpected result. Current code loosk to be expecting either `0` or a positive integer.

This was enough to let me complete a number of large search tasks.

Possible issues:
* This could get stuck in a loop -- there's no give-up clause if the API decides to consistently return `total: None`
* I only checked very briefly whether 0 search results avoid this retry code -- searching for non existent categories with 0 results does not get stuck in a loop, but there may be other cases which need checking?
* `total:None` looks like an API bug which would be masked by this workaround without understanding of the root cause.