### PR TITLE
Fix mypy error and a few typos too

### DIFF
--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -5,13 +5,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v4
         with:
+          python-version: 3.x
           cache: pip
       - run: pip install --upgrade pip wheel
       - run: pip install .[all]
       - run: black --check . || true
       - run: flake8 .  # See setup.cfg for configuration
       - run: pip install -r pex-requirements.txt -r tests/requirements.txt
-      - run: mypy .  # See setup.cfg for configuration
       - run: safety check

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
   #        - flake8
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.2.0
+    rev: v4.3.0
     hooks:
       - id: check-builtin-literals
       - id: check-executables-have-shebangs
@@ -37,7 +37,7 @@ repos:
           - --skip=B101,B103,B105,B106,B303,B324,B318,B404,B408,B602
 
   - repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 22.10.0
     hooks:
       - id: black
         language_version: python3  # Should be a command that runs python3.6+
@@ -46,7 +46,7 @@ repos:
           - --skip-string-normalization
 
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.1.0
+    rev: v2.2.2
     hooks:
       - id: codespell  # See setup.cfg for args
 
@@ -67,26 +67,20 @@ repos:
           - --profile=black
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.950
+    rev: v0.982
     hooks:
       - id: mypy
         additional_dependencies:
-          - tqdm-stubs
-          - types-docopt
-          - types-jsonpatch
-          - types-requests
-          - types-setuptools
-          - types-ujson
-          - types-urllib3
+          - types-all
 
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.32.1
+    rev: v3.2.0
     hooks:
       - id: pyupgrade
         args:
           - --py37-plus
 
   - repo: https://github.com/asottile/setup-cfg-fmt
-    rev: v1.20.1
+    rev: v2.2.0
     hooks:
       - id: setup-cfg-fmt

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -278,7 +278,7 @@ Release History
 
 **Features and Improvements**
 
-- Documnetation updates.
+- Documentation updates.
 - Added support for write-many to modify_metadata.
 
 **Bugfixes**

--- a/internetarchive/item.py
+++ b/internetarchive/item.py
@@ -342,7 +342,7 @@ class Item(BaseItem):
 
         :param reduced_priority: Submit your derive at a lower priority.
                                  This option is helpful to get around rate-limiting.
-                                 Your task will more likey be accepted, but it might
+                                 Your task will more likely be accepted, but it might
                                  not run for a long time. Note that you still may be
                                  subject to rate-limiting.
 
@@ -382,7 +382,7 @@ class Item(BaseItem):
 
         :param reduced_priority: Submit your derive at a lower priority.
                                  This option is helpful to get around rate-limiting.
-                                 Your task will more likey be accepted, but it might
+                                 Your task will more likely be accepted, but it might
                                  not run for a long time. Note that you still may be
                                  subject to rate-limiting. This is different than
                                  ``priority`` in that it will allow you to possibly
@@ -427,7 +427,7 @@ class Item(BaseItem):
 
         :param reduced_priority: Submit your derive at a lower priority.
                                  This option is helpful to get around rate-limiting.
-                                 Your task will more likey be accepted, but it might
+                                 Your task will more likely be accepted, but it might
                                  not run for a long time. Note that you still may be
                                  subject to rate-limiting. This is different than
                                  ``priority`` in that it will allow you to possibly
@@ -464,7 +464,7 @@ class Item(BaseItem):
 
         :param reduced_priority: Submit your derive at a lower priority.
                                  This option is helpful to get around rate-limiting.
-                                 Your task will more likey be accepted, but it might
+                                 Your task will more likely be accepted, but it might
                                  not run for a long time. Note that you still may be
                                  subject to rate-limiting. This is different than
                                  ``priority`` in that it will allow you to possibly

--- a/internetarchive/session.py
+++ b/internetarchive/session.py
@@ -377,7 +377,7 @@ class ArchiveSession(requests.sessions.Session):
 
         :param reduced_priority: Submit your derive at a lower priority.
                                  This option is helpful to get around rate-limiting.
-                                 Your task will more likey be accepted, but it might
+                                 Your task will more likely be accepted, but it might
                                  not run for a long time. Note that you still may be
                                  subject to rate-limiting. This is different than
                                  ``priority`` in that it will allow you to possibly

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,10 +17,6 @@ classifiers =
     Programming Language :: Python
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.7
-    Programming Language :: Python :: 3.8
-    Programming Language :: Python :: 3.9
-    Programming Language :: Python :: 3.10
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy
 


### PR DESCRIPTION
```
pre-commit autoupdate
pre-commit run --all-files
```
* Fix some typos raised by the newer version of codespell.
* Run `mypy` in pre-commit, not in `lint-python`
* Use `types-all` on mypy to fix the `maximum semantic analysis iteration count reached` error.