### PR TITLE
SearchIterator: Remove unused Python 2 .next() method

### DIFF
--- a/internetarchive/search.py
+++ b/internetarchive/search.py
@@ -276,10 +276,7 @@ class SearchIterator:
         return self.search.num_found
 
     def __next__(self):
-        return self.iterator.__next__()
-
-    def next(self):
-        return self.iterator.next()
+        return next(self.iterator)
 
     def __iter__(self):
         return self


### PR DESCRIPTION
Remove the unused Python 2 `iterator.next()` method in favor of the Python 3 `iterator.__next__()` method and the [builtin `next()` function](https://docs.python.org/3/library/functions.html#next) as discussed at:
* https://portingguide.readthedocs.io/en/latest/iterators.html#new-iteration-protocol-next
* [`https://docs.python.org/3/library/stdtypes.html#iterator.__next__`](https://docs.python.org/3/library/stdtypes.html#iterator.__next__)