### PR TITLE
ci: Add Python 3.11 and PyPy 3.9 to the testing

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -10,8 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v4
         with:
+          python-version: 3.x
           cache: pip
       - run: pip install pre-commit
       - run: pre-commit --version

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -6,10 +6,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.7', '3.8', '3.9', '3.10', 'pypy-3.7', 'pypy-3.8']
+        python: ['3.7', '3.8', '3.9', '3.10', '3.11', 'pypy-3.7', 'pypy-3.8', 'pypy-3.9']
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
           cache: pip

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      max-parallel: 4
+      max-parallel: 1  # Avoid timeout errors
       matrix:
         python: ['3.7', '3.8', '3.9', '3.10', '3.11', 'pypy-3.7', 'pypy-3.8', 'pypy-3.9']
     steps:

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -5,6 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
+      max-parallel: 4
       matrix:
         python: ['3.7', '3.8', '3.9', '3.10', '3.11', 'pypy-3.7', 'pypy-3.8', 'pypy-3.9']
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
   #        - flake8
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.2.0
+    rev: v4.3.0
     hooks:
       - id: check-builtin-literals
       - id: check-executables-have-shebangs
@@ -37,7 +37,7 @@ repos:
           - --skip=B101,B103,B105,B106,B303,B324,B318,B404,B408,B602
 
   - repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 22.10.0
     hooks:
       - id: black
         language_version: python3  # Should be a command that runs python3.6+
@@ -46,7 +46,7 @@ repos:
           - --skip-string-normalization
 
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.1.0
+    rev: v2.2.2
     hooks:
       - id: codespell  # See setup.cfg for args
 
@@ -67,7 +67,7 @@ repos:
           - --profile=black
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.950
+    rev: v0.990
     hooks:
       - id: mypy
         additional_dependencies:
@@ -80,13 +80,13 @@ repos:
           - types-urllib3
 
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.32.1
+    rev: v3.2.2
     hooks:
       - id: pyupgrade
         args:
           - --py37-plus
 
   - repo: https://github.com/asottile/setup-cfg-fmt
-    rev: v1.20.1
+    rev: v2.2.0
     hooks:
       - id: setup-cfg-fmt

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -278,7 +278,7 @@ Release History
 
 **Features and Improvements**
 
-- Documnetation updates.
+- Documentation updates.
 - Added support for write-many to modify_metadata.
 
 **Bugfixes**

--- a/internetarchive/api.py
+++ b/internetarchive/api.py
@@ -463,7 +463,7 @@ def search_items(
     params: Mapping | None = None,
     full_text_search: bool = False,
     dsl_fts: bool = False,
-    archive_session: session.ArchiveSession = None,
+    archive_session: session.ArchiveSession | None = None,
     config: Mapping | None = None,
     config_file: str | None = None,
     http_adapter_kwargs: MutableMapping | None = None,

--- a/internetarchive/cli/ia_search.py
+++ b/internetarchive/cli/ia_search.py
@@ -41,6 +41,8 @@ examples:
 
     ia search 'collection:nasa' --parameters rows:1
 """
+from __future__ import annotations
+
 import sys
 from itertools import chain
 
@@ -54,7 +56,7 @@ from internetarchive.exceptions import AuthenticationError
 from internetarchive.utils import json
 
 
-def main(argv, session: ArchiveSession = None) -> None:
+def main(argv, session: ArchiveSession | None = None) -> None:
     args = docopt(__doc__, argv=argv)
 
     # Validate args.

--- a/internetarchive/item.py
+++ b/internetarchive/item.py
@@ -342,7 +342,7 @@ class Item(BaseItem):
 
         :param reduced_priority: Submit your derive at a lower priority.
                                  This option is helpful to get around rate-limiting.
-                                 Your task will more likey be accepted, but it might
+                                 Your task will more likely be accepted, but it might
                                  not run for a long time. Note that you still may be
                                  subject to rate-limiting.
 
@@ -382,7 +382,7 @@ class Item(BaseItem):
 
         :param reduced_priority: Submit your derive at a lower priority.
                                  This option is helpful to get around rate-limiting.
-                                 Your task will more likey be accepted, but it might
+                                 Your task will more likely be accepted, but it might
                                  not run for a long time. Note that you still may be
                                  subject to rate-limiting. This is different than
                                  ``priority`` in that it will allow you to possibly
@@ -427,7 +427,7 @@ class Item(BaseItem):
 
         :param reduced_priority: Submit your derive at a lower priority.
                                  This option is helpful to get around rate-limiting.
-                                 Your task will more likey be accepted, but it might
+                                 Your task will more likely be accepted, but it might
                                  not run for a long time. Note that you still may be
                                  subject to rate-limiting. This is different than
                                  ``priority`` in that it will allow you to possibly
@@ -464,7 +464,7 @@ class Item(BaseItem):
 
         :param reduced_priority: Submit your derive at a lower priority.
                                  This option is helpful to get around rate-limiting.
-                                 Your task will more likey be accepted, but it might
+                                 Your task will more likely be accepted, but it might
                                  not run for a long time. Note that you still may be
                                  subject to rate-limiting. This is different than
                                  ``priority`` in that it will allow you to possibly

--- a/internetarchive/session.py
+++ b/internetarchive/session.py
@@ -157,7 +157,7 @@ class ArchiveSession(requests.sessions.Session):
         super().rebuild_auth(prepared_request, response)
 
     def mount_http_adapter(self, protocol: str | None = None, max_retries: int | None = None,
-                           status_forcelist: list | None = None, host: str = None) -> None:
+                           status_forcelist: list | None = None, host: str | None = None) -> None:
         """Mount an HTTP adapter to the
         :class:`ArchiveSession <ArchiveSession>` object.
 
@@ -377,7 +377,7 @@ class ArchiveSession(requests.sessions.Session):
 
         :param reduced_priority: Submit your derive at a lower priority.
                                  This option is helpful to get around rate-limiting.
-                                 Your task will more likey be accepted, but it might
+                                 Your task will more likely be accepted, but it might
                                  not run for a long time. Note that you still may be
                                  subject to rate-limiting. This is different than
                                  ``priority`` in that it will allow you to possibly

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,10 +17,6 @@ classifiers =
     Programming Language :: Python
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.7
-    Programming Language :: Python :: 3.8
-    Programming Language :: Python :: 3.9
-    Programming Language :: Python :: 3.10
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -67,8 +67,10 @@ test =
     responses==0.20.0
 types =
     tqdm-stubs>=0.2.0
+    types-colorama
     types-docopt>=0.6.10,<0.7.0
     types-jsonpatch>=0.1.0a0
+    types-pygments
     types-requests>=2.25.0,<3.0.0
     types-setuptools
     types-ujson>=4.2.0

--- a/tests/cli/test_ia_download.py
+++ b/tests/cli/test_ia_download.py
@@ -2,6 +2,8 @@ import os
 import sys
 import time
 
+import pytest
+
 from tests.conftest import NASA_EXPECTED_FILES, call_cmd, files_downloaded
 
 

--- a/tests/cli/test_ia_download.py
+++ b/tests/cli/test_ia_download.py
@@ -10,10 +10,10 @@ def test_no_args(tmpdir_ch):
     assert files_downloaded(path='nasa') == NASA_EXPECTED_FILES
 
 
-# TODO: Fix this test
-# def test_https(tmpdir_ch):
-#    call_cmd('ia download nasa')
-#    assert files_downloaded(path='nasa') == NASA_EXPECTED_FILES
+@pytest.mark.xfail("CI" in os.environ, reason="May timeout on continuous integration")
+def test_https(tmpdir_ch):
+    call_cmd('ia download nasa')
+    assert files_downloaded(path='nasa') == NASA_EXPECTED_FILES
 
 
 def test_dry_run():

--- a/tests/cli/test_ia_download.py
+++ b/tests/cli/test_ia_download.py
@@ -10,9 +10,10 @@ def test_no_args(tmpdir_ch):
     assert files_downloaded(path='nasa') == NASA_EXPECTED_FILES
 
 
-def test_https(tmpdir_ch):
-    call_cmd('ia download nasa')
-    assert files_downloaded(path='nasa') == NASA_EXPECTED_FILES
+# TODO: Fix this test
+# def test_https(tmpdir_ch):
+#    call_cmd('ia download nasa')
+#    assert files_downloaded(path='nasa') == NASA_EXPECTED_FILES
 
 
 def test_dry_run():

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37,py38,py39,py310,pypy37,pypy38
+envlist = py37,py38,py39,py310,py311,pypy37,pypy38,pypy39
 
 [testenv]
 deps = -r tests/requirements.txt
@@ -18,3 +18,6 @@ basepython=python3.9
 
 [testenv:py310]
 basepython=python3.10
+
+[testenv:py311]
+basepython=python3.11


### PR DESCRIPTION
* https://docs.python.org/3/whatsnew/3.11.html
* https://www.pypy.org/download_advanced.html
* `pre-commit autoupdate`
* PEP 484: mypy now defaults to `--no_implicit_optional=True`
* mypy: `pip install types-colorama types-Pygments`
* Fix new typos in `codespell`
* pytest.xfail flakey `test_https()` which times out intermittently