### PR TITLE
fix iter over zero search results

### DIFF
--- a/internetarchive/search.py
+++ b/internetarchive/search.py
@@ -153,7 +153,7 @@ class Search:
             if j.get('error'):
                 yield j
             if not num_found:
-                num_found = int(j['total'])
+                num_found = int(j['total'], 0)
             if not self._num_found:
                 self._num_found = num_found
             self._handle_scrape_error(j)


### PR DESCRIPTION
scrape returns `total: None` when count == 0

results in TypeError when iter_as_items over a search with 0 results: `TypeError: int() argument must be a string, a bytes-like object or a number, not 'NoneType'`