### PR TITLE
Fix TypeError when iterating over 0 search results

### DIFF
--- a/internetarchive/search.py
+++ b/internetarchive/search.py
@@ -153,7 +153,7 @@ class Search:
             if j.get('error'):
                 yield j
             if not num_found:
-                num_found = int(j['total'])
+                num_found = int(j['total'] or 0)
             if not self._num_found:
                 self._num_found = num_found
             self._handle_scrape_error(j)


### PR DESCRIPTION
Scrape can result in `j` where `count: 0, total: None` resulting in:
`TypeError: int() argument must be a string, a bytes-like object or a number, not 'NoneType'`