### PR TITLE
Limit `urllib3` version to < 2 because it breaks `internetarchive/session.py`

### DIFF
--- a/pex-requirements.txt
+++ b/pex-requirements.txt
@@ -5,4 +5,4 @@ requests>=2.25.0,<3.0.0
 schema>=0.4.0
 setuptools
 tqdm>=4.0.0
-urllib3>=1.26.0
+urllib3>=1.26.0,<2.0.0


### PR DESCRIPTION
See the error we get in production when we use `urllib3` 2.x
```
Oct 31 01:40:13 wwwb-spn26.us.archive.org instawayback_uploader.py[49361]: Traceback (most recent call last):
Oct 31 01:40:13 wwwb-spn26.us.archive.org instawayback_uploader.py[49361]:   File "/opt/liveweb/lib/python3.8/site-packages/spn_uploader/processors.py", line 121, in mark_uploaded
Oct 31 01:40:13 wwwb-spn26.us.archive.org instawayback_uploader.py[49361]:     item = ia.get_item(upload_item)
Oct 31 01:40:13 wwwb-spn26.us.archive.org instawayback_uploader.py[49361]:   File "/opt/liveweb/lib/python3.8/site-packages/internetarchive/api.py", line 115, in get_item
Oct 31 01:40:13 wwwb-spn26.us.archive.org instawayback_uploader.py[49361]:     archive_session = get_session(config, config_file, debug, http_adapter_kwargs)
Oct 31 01:40:13 wwwb-spn26.us.archive.org instawayback_uploader.py[49361]:   File "/opt/liveweb/lib/python3.8/site-packages/internetarchive/api.py", line 75, in get_session
Oct 31 01:40:13 wwwb-spn26.us.archive.org instawayback_uploader.py[49361]:     return session.ArchiveSession(config, config_file, debug, http_adapter_kwargs)
Oct 31 01:40:13 wwwb-spn26.us.archive.org instawayback_uploader.py[49361]:   File "/opt/liveweb/lib/python3.8/site-packages/internetarchive/session.py", line 110, in __init__
Oct 31 01:40:13 wwwb-spn26.us.archive.org instawayback_uploader.py[49361]:     self.mount_http_adapter()
Oct 31 01:40:13 wwwb-spn26.us.archive.org instawayback_uploader.py[49361]:   File "/opt/liveweb/lib/python3.8/site-packages/internetarchive/session.py", line 162, in mount_http_adapter
Oct 31 01:40:13 wwwb-spn26.us.archive.org instawayback_uploader.py[49361]:     method_whitelist=Retry.DEFAULT_METHOD_WHITELIST,
Oct 31 01:40:13 wwwb-spn26.us.archive.org instawayback_uploader.py[49361]: AttributeError: type object 'Retry' has no attribute 'DEFAULT_METHOD_WHITELIST'
```