### PR TITLE
Fix mypy's worries that exc.response may be None

### DIFF
--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -14,5 +14,5 @@ jobs:
       - run: black --check --skip-string-normalization . || true
       - run: ruff --format=github .  # See pyproject.toml for configuration
       - run: pip install -r pex-requirements.txt -r tests/requirements.txt
-      - run: mypy .  # See setup.cfg for configuration
+      - run: mypy --non-itneractive .  # See setup.cfg for configuration
       - run: safety check || true  # Temporary fix for https://pyup.io/v/51457/f17

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -14,5 +14,5 @@ jobs:
       - run: black --check --skip-string-normalization . || true
       - run: ruff --format=github .  # See pyproject.toml for configuration
       - run: pip install -r pex-requirements.txt -r tests/requirements.txt
-      - run: mypy --non-itneractive .  # See setup.cfg for configuration
+      - run: mypy --non-interactive .  # See setup.cfg for configuration
       - run: safety check || true  # Temporary fix for https://pyup.io/v/51457/f17

--- a/internetarchive/cli/ia_reviews.py
+++ b/internetarchive/cli/ia_reviews.py
@@ -68,7 +68,7 @@ def main(argv, session: ArchiveSession) -> None:
             print(r.text)
             sys.exit(0)
         except HTTPError as exc:
-            if exc.response.status_code == 404:
+            if exc.response and exc.response.status_code == 404:
                 sys.exit(0)
             else:
                 raise exc

--- a/internetarchive/item.py
+++ b/internetarchive/item.py
@@ -1105,8 +1105,9 @@ class Item(BaseItem):
                 response.close()
                 return response
             except HTTPError as exc:
+                assert exc.response  # noqa: PT017 - Placate mypy
                 try:
-                    msg = get_s3_xml_text(exc.response.content)
+                    msg = get_s3_xml_text(exc.response.text)
                 except ExpatError:  # probably HTTP 500 error and response is invalid XML
                     msg = ('IA S3 returned invalid XML '
                            f'(HTTP status code {exc.response.status_code}). '

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,7 @@ max-complexity = 33
 [tool.ruff.pylint]
 max-args = 23
 max-branches = 33
-max-statements = 124
+max-statements = 125
 
 [tool.ruff.per-file-ignores]
 "__init__.py" = ["E402"]


### PR DESCRIPTION
https://github.com/jjjake/internetarchive/actions are currently failing because `mypy` is worried that `exc.response` could be `None`.  Let's fix that to placate `mypy` and add 1 line to our max statements limit so that pre-commit tests are green again ✅ .

Note that `pre-commit autoupdate` should be run in a _separate_ pull request to upgrade our linting tools.  This should be done every few months or automated by enabling https://pre-commit.ci as is done in Open Library.

% `pre-commit autoupdate`
```
[https://github.com/pre-commit/pre-commit-hooks] updating v4.4.0 -> v4.5.0
[https://github.com/charliermarsh/ruff-pre-commit] updating v0.0.269 -> v0.1.5
[https://github.com/psf/black] updating 23.3.0 -> 23.11.0
[https://github.com/codespell-project/codespell] updating v2.2.4 -> v2.2.6
[https://github.com/pre-commit/mirrors-mypy] updating v1.3.0 -> v1.7.0
[https://github.com/asottile/setup-cfg-fmt] updating v2.2.0 -> v2.5.0
```