### PR TITLE
Protect against nonetype return in search

### DIFF
--- a/internetarchive/search.py
+++ b/internetarchive/search.py
@@ -153,7 +153,7 @@ class Search:
             if j.get('error'):
                 yield j
             if not num_found:
-                num_found = int(j['total'])
+                num_found = int(j.get('total') or '0')
             if not self._num_found:
                 self._num_found = num_found
             self._handle_scrape_error(j)


### PR DESCRIPTION
Sometimes search results json returns a `None` value for `'total'`, which we need to interpret as `0`.

`{'items': [], 'count': 0, 'total': None, 'request_error': '(no hits returned)'}`