### PR TITLE
Switch to importlib-metadata to drop deprecated pkg_resources

### DIFF
--- a/internetarchive/cli/ia.py
+++ b/internetarchive/cli/ia.py
@@ -64,7 +64,10 @@ import os
 import sys
 
 from docopt import docopt, printable_usage
-from pkg_resources import DistributionNotFound, iter_entry_points
+if sys.version_info < (3, 10):
+  from importlib_metadata import entry_points
+else:
+  from importlib.metadata import entry_points
 from schema import Or, Schema, SchemaError  # type: ignore[import]
 
 from internetarchive import __version__
@@ -97,11 +100,11 @@ def load_ia_module(cmd: str):
             return __import__(_module, fromlist=['internetarchive.cli'])
         else:
             _module = f'ia_{cmd}'
-            for ep in iter_entry_points('internetarchive.cli.plugins'):
+            for ep in entry_points(group='internetarchive.cli.plugins'):
                 if ep.name == _module:
                     return ep.load()
             raise ImportError
-    except (ImportError, DistributionNotFound):
+    except (ImportError):
         print(f"error: '{cmd}' is not an ia command! See 'ia help'",
               file=sys.stderr)
         matches = '\t'.join(difflib.get_close_matches(cmd, cmd_aliases.values()))

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,6 +26,7 @@ packages =
     internetarchive.cli
 install_requires =
     docopt>=0.6.0,<0.7.0
+    importlib-metadata >= 3.6.0 ; python_version <= "3.10"
     jsonpatch>=0.4
     requests>=2.25.0,<3.0.0
     schema>=0.4.0


### PR DESCRIPTION
According to https://setuptools.pypa.io/en/latest/pkg_resources.html, pkg_resources has been deprecated and importlib-metadata is recommended. `DistributionNotFound` only can be thrown from `find_plugins()` which is not used by ia. Tested with plugin https://github.com/JesseWeinstein/ia_recent.

Closes: https://github.com/jjjake/internetarchive/issues/613