### PR TITLE
Fix automatic size hint on uploads

### DIFF
--- a/tests/cli/test_ia_upload.py
+++ b/tests/cli/test_ia_upload.py
@@ -124,6 +124,27 @@ def test_ia_upload_size_hint(capsys, tmpdir_ch, nasa_mocker):
     assert 'Accept-Encoding:gzip, deflate' in err
 
 
+def test_ia_upload_automatic_size_hint_files(capsys, tmpdir_ch, nasa_mocker):
+    with open('foo', 'w') as fh:
+        fh.write('foo')
+    with open('bar', 'w') as fh:
+        fh.write('bar')
+
+    ia_call(['ia', 'upload', '--debug', 'nasa', 'foo', 'bar'])
+    out, err = capsys.readouterr()
+    assert 'x-archive-size-hint:6' in err
+
+def test_ia_upload_automatic_size_hint_dir(capsys, tmpdir_ch, nasa_mocker):
+    with open('foo', 'w') as fh:
+        fh.write('foo')
+    with open('bar', 'w') as fh:
+        fh.write('bar')
+
+    ia_call(['ia', 'upload', '--debug', 'nasa', '.'])
+    out, err = capsys.readouterr()
+    assert 'x-archive-size-hint:6' in err
+
+
 def test_ia_upload_unicode(tmpdir_ch, caplog):
     with open('தமிழ் - baz ∆.txt', 'w') as fh:
         fh.write('unicode foo')


### PR DESCRIPTION
When uploading without a size hint (via headers or `--size-hint`), a x-archive-size-hint header is added automatically. However, prior to this commit, the value was the individual file size on each file's `PUT` request. This effectively made the size hint useless because it does not, in fact, provide a size hint for the total item size to the S3 backend at item creation time.

Notes on detailed changes to implement this:

* Rename `internetarchive.utils.recursive_file_count` to `recursive_file_count_and_size`, adding a wrapper for backwards compatibility
* Add support for paths (rather than only file-like objects) to `internetarchive.utils.get_file_size`
* Add a `internetarchive.utils.is_filelike_obj` helper function
* Fix a bug introduced by 62c85133090e21659f09964fedd4c18ae4a27483 where `total_files` would never be `None` and so `recursive_file_count` was never called, possibly leading to incorrect derive queueing.
* Add tests for the fixed behaviour