### PR TITLE
Bump test suite to current versions

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -7,7 +7,7 @@ jobs:
       fail-fast: false
       max-parallel: 1  # Avoid timeout errors
       matrix:
-        python: ['3.7', '3.8', '3.9', '3.10', '3.11', 'pypy-3.7', 'pypy-3.8', 'pypy-3.9']
+        python: ['3.8', '3.9', '3.10', '3.11', '3.12', 'pypy-3.9', 'pypy-3.10']
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4

--- a/tox.ini
+++ b/tox.ini
@@ -1,14 +1,11 @@
 [tox]
-envlist = py37,py38,py39,py310,py311,pypy37,pypy38,pypy39
+envlist = py38,py39,py310,py311,py312,pypy39,pypy310
 
 [testenv]
 deps = -r tests/requirements.txt
 # See setup.cfg for changes to default settings
 commands = ruff .
            pytest {posargs}
-
-[testenv:py37]
-basepython=python3.7
 
 [testenv:py38]
 basepython=python3.8
@@ -21,3 +18,6 @@ basepython=python3.10
 
 [testenv:py311]
 basepython=python3.11
+
+[testenv:py312]
+basepython=python3.12


### PR DESCRIPTION
CPython 3.7, PyPy 3.7, and PyPy 3.8 are EOL and unsupported.

The test on 3.12 currently fails. This is due to #613, and merging this PR should probably wait for #621 (or we should add a dependency on `setuptools` until that is resolved, as mentioned in <https://github.com/jjjake/internetarchive/issues/613#issuecomment-1872954045>).