### PR TITLE
Fix linting: disable mypy --install-types

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -80,7 +80,6 @@ ignore-words-list = alers
 [mypy]
 exclude = ^\.git/|^__pycache__/|^docs/source/conf.py$|^old/|^build/|^dist/|\.tox
 python_version = 3.9
-install_types = True
 pretty = True
 scripts_are_modules = True
 show_error_codes = True


### PR DESCRIPTION
`pip install .[all]` already installs the third-party hints, and `--install-types` prompts for confirmation, breaking the CI.