### PR TITLE
Bump actions/checkout to v4

### DIFF
--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -4,7 +4,7 @@ jobs:
   lint_python:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
         with:
           cache: pip

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -9,7 +9,7 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x

--- a/.github/workflows/test_install.yml
+++ b/.github/workflows/test_install.yml
@@ -11,6 +11,6 @@ jobs:
       matrix:
         setuptools-version: ["45.2.0", "58.1.0", "62.4.0"]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: pip install setuptools=="${{ matrix.setuptools-version }}"
       - run: pip install .

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -9,7 +9,7 @@ jobs:
       matrix:
         python: ['3.7', '3.8', '3.9', '3.10', '3.11', 'pypy-3.7', 'pypy-3.8', 'pypy-3.9']
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}


### PR DESCRIPTION
v3 uses Node 16, which is deprecated in GitHub Actions: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

This solves the deprecation warnings at the bottom of recent Actions runs (cf. <https://github.com/jjjake/internetarchive/pull/628#issuecomment-1943071711>).