### PR TITLE
Bump PyPy tests to current versions

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -7,7 +7,7 @@ jobs:
       fail-fast: false
       max-parallel: 1  # Avoid timeout errors
       matrix:
-        python: ['3.8', '3.9', '3.10', '3.11', '3.12', 'pypy-3.7', 'pypy-3.8', 'pypy-3.9']
+        python: ['3.8', '3.9', '3.10', '3.11', '3.12', 'pypy-3.9', 'pypy-3.10']
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py38,py39,py310,py311,py312,pypy37,pypy38,pypy39
+envlist = py38,py39,py310,py311,py312,pypy39,pypy310
 
 [testenv]
 deps = -r tests/requirements.txt


### PR DESCRIPTION
PyPy 3.7 and PyPy 3.8 are EOL and unsupported (although CPython 3.8 is not yet).