### PR TITLE
Remove circular reference check on item metadata hashing

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -8,6 +8,9 @@ jobs:
       max-parallel: 1  # Avoid timeout errors
       matrix:
         python: ['3.8', '3.9', '3.10', '3.11', '3.12', 'pypy-3.9', 'pypy-3.10']
+        envname: ['py']  # To allow testing more special configurations below
+        include:
+          - { python: '3.12', envname: 'py312ujson' }  # With optional ujson dependency
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -15,4 +18,4 @@ jobs:
           python-version: ${{ matrix.python }}
           cache: pip
       - run: pip install tox
-      - run: tox -e py
+      - run: tox -e ${{ matrix.envname }}

--- a/internetarchive/item.py
+++ b/internetarchive/item.py
@@ -131,8 +131,7 @@ class BaseItem:
         without_excluded_keys = {
             k: v for k, v in self.item_metadata.items()
             if k not in self.EXCLUDED_ITEM_METADATA_KEYS}
-        return hash(json.dumps(without_excluded_keys,
-                               sort_keys=True, check_circular=False))  # type: ignore
+        return hash(json.dumps(without_excluded_keys, sort_keys=True))  # type: ignore
 
 
 class Item(BaseItem):

--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -706,3 +706,7 @@ def test_modify_metadata(nasa_item, nasa_metadata):
                                   secret_key='b')
         # Test that item re-initializes
         assert nasa_item.metadata['title'] == 'new title'
+
+
+def test_hash_item(nasa_metadata, nasa_item, session):
+    assert hash(nasa_item)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py38,py39,py310,py311,py312,pypy39,pypy310
+envlist = py38,py39,py310,py311,py312,py312ujson,pypy39,pypy310
 
 [testenv]
 deps = -r tests/requirements.txt
@@ -21,3 +21,8 @@ basepython=python3.11
 
 [testenv:py312]
 basepython=python3.12
+
+[testenv:py312ujson]
+basepython=python3.12
+deps = -r tests/requirements.txt
+       ujson


### PR DESCRIPTION
Unless someone actively tries to break things by passing a crafted object, it should not generally be possible for there to be circular references. In addition, if someone were to do that, things would break in many other places, e.g. `MetadataPreparedRequest`, anyway. Guarding against a crash on hashing in that specific unusual scenario does not seem worthwhile and breaks when ujson is in use.

Fixes #540

Also adds a test suite run with ujson installed so we can catch such things in the future.