### PR TITLE
Add refresh opt-out on Item.modify_metadata()

### DIFF
--- a/internetarchive/api.py
+++ b/internetarchive/api.py
@@ -209,6 +209,7 @@ def modify_metadata(
         secret_key=secret_key,
         debug=debug,
         request_kwargs=request_kwargs,
+        refresh=False
     )
 
 

--- a/internetarchive/cli/ia_metadata.py
+++ b/internetarchive/cli/ia_metadata.py
@@ -91,7 +91,7 @@ def modify_metadata(item: item.Item, metadata: Mapping, args: Mapping) -> Respon
         r = item.modify_metadata(metadata, target=args['--target'], append=append,
                                  expect=expect, priority=args['--priority'],
                                  append_list=append_list, headers=args['--header'],
-                                 insert=insert, timeout=args['--timeout'])
+                                 insert=insert, timeout=args['--timeout'], refresh=False)
         assert isinstance(r, Response)  # mypy: modify_metadata() -> Request | Response
     except ItemLocateError as exc:
         print(f'{item.identifier} - error: {exc}', file=sys.stderr)

--- a/internetarchive/item.py
+++ b/internetarchive/item.py
@@ -779,7 +779,8 @@ class Item(BaseItem):
                         debug: bool = False,
                         headers: Mapping | None = None,
                         request_kwargs: Mapping | None = None,
-                        timeout: int | float | None = None) -> Request | Response:
+                        timeout: int | float | None = None,
+                        refresh: bool = True) -> Request | Response:
         """Modify the metadata of an existing item on Archive.org.
 
         Note: The Metadata Write API does not yet comply with the
@@ -800,6 +801,8 @@ class Item(BaseItem):
 
         :param append_list: Append values to an existing multi-value
                             metadata field. No duplicate values will be added.
+
+        :param refresh: Refresh the item metadata after the request.
 
         :returns: A Request if debug else a Response.
 
@@ -850,7 +853,8 @@ class Item(BaseItem):
             return prepared_request
         resp = self.session.send(prepared_request, **request_kwargs)
         # Re-initialize the Item object with the updated metadata.
-        self.refresh()
+        if refresh:
+            self.refresh()
         return resp
 
     # TODO: `list` parameter name shadows the Python builtin

--- a/tests/cli/test_ia_metadata.py
+++ b/tests/cli/test_ia_metadata.py
@@ -32,9 +32,8 @@ def test_ia_metadata_modify(capsys):
     md_rsp = ('{"success":true,"task_id":447613301,'
               '"log":"https://catalogd.archive.org/log/447613301"}')
     with IaRequestsMock() as rsps:
-        rsps.add_metadata_mock('nasa')
+        rsps.add_metadata_mock('nasa', method=responses.GET)
         rsps.add_metadata_mock('nasa', body=md_rsp, method=responses.POST)
-        rsps.add_metadata_mock('nasa')
         valid_key = f'foo-{int(time())}'
         ia_call(['ia', 'metadata', '--modify', f'{valid_key}:test_value', 'nasa'])
         out, err = capsys.readouterr()


### PR DESCRIPTION
To shave off a bit of time when modifying metadata on items as the end of an operation.