### PR TITLE
Update `iarequest.py` to fix `requests.exceptions.InvalidHeader`

### DIFF
--- a/internetarchive/iarequest.py
+++ b/internetarchive/iarequest.py
@@ -125,6 +125,8 @@ class S3PreparedRequest(requests.models.PreparedRequest):
                 metadata['scanner'] = [metadata['scanner'], scanner]
             else:
                 metadata['scanner'] = scanner
+            if (isinstance(metadata['scanner'], list)):
+                metadata['scanner'] = ', '.join(metadata['scanner'])
         prepared_metadata = prepare_metadata(metadata)
         prepared_file_metadata = prepare_metadata(file_metadata)
 


### PR DESCRIPTION
I'm using this library in conjunction with [Tubeup](https://github.com/bibanon/tubeup).  Whenever I use it, I get this full output:

```
PS C:\Users\USERNAME> tubeup https://soundcloud.com/shokhi-chumoghiqael-9/lllaaala-2024-11-05
[soundcloud] Original download format is only available for registered users. Use --cookies, --cookies-from-browser, --username and --password, --netrc-cmd, or --netrc (soundcloud) to provide account credentials. See  https://github.com/yt-dlp/yt-dlp/wiki/FAQ#how-do-i-pass-cookies-to-yt-dlp  for how to manually pass cookies
[soundcloud] Original download format is only available for registered users. Use --cookies, --cookies-from-browser, --username and --password, --netrc-cmd, or --netrc (soundcloud) to provide account credentials. See  https://github.com/yt-dlp/yt-dlp/wiki/FAQ#how-do-i-pass-cookies-to-yt-dlp  for how to manually pass cookies
LƏLƏLƏAAALA (2024-11-05)
There are no annotations to write.
[download]  99.1% of        N/A at  653.21KiB/s ETA 00:01
Downloaded C:\Users\USERNAME\.tubeup\downloads\1954371115.opus
1954371115: Possible MPEG-TS in MP4 container or malformed AAC timestamps
 uploading 1954371115.info.json: 100%|██████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00, 15.93MiB/s]
 uploading 1954371115.jpg: 100%|████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:01<00:00,  1.15s/MiB]
 uploading 1954371115.opus:   0%|                                                                                                       | 0/4 [00:00<?, ?MiB/s]
An exception just occured, if you found this exception isn't related with any of your connection problem, please report this issue to https://github.com/bibanon/tubeup/issues
Traceback (most recent call last):
  File "C:\Users\USERNAME\AppData\Roaming\Python\Python312\site-packages\tubeup\__main__.py", line 99, in main
    for identifier, meta in tu.archive_urls(URLs, metadata,
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\USERNAME\AppData\Roaming\Python\Python312\site-packages\tubeup\TubeUp.py", line 416, in archive_urls
    identifier, meta = self.upload_ia(basename, custom_meta)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\USERNAME\AppData\Roaming\Python\Python312\site-packages\tubeup\TubeUp.py", line 378, in upload_ia
    item.upload(files_to_upload, metadata=metadata, retries=9001,
  File "C:\Users\USERNAME\AppData\Roaming\Python\Python312\site-packages\internetarchive\item.py", line 1283, in upload
    resp = self.upload_file(body,
           ^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\USERNAME\AppData\Roaming\Python\Python312\site-packages\internetarchive\item.py", line 1087, in upload_file
    prepared_request = request.prepare()
                       ^^^^^^^^^^^^^^^^^
  File "C:\Users\USERNAME\AppData\Roaming\Python\Python312\site-packages\internetarchive\iarequest.py", line 67, in prepare
    p.prepare(
  File "C:\Users\USERNAME\AppData\Roaming\Python\Python312\site-packages\internetarchive\iarequest.py", line 93, in prepare
    self.prepare_headers(headers, metadata,
  File "C:\Users\USERNAME\AppData\Roaming\Python\Python312\site-packages\internetarchive\iarequest.py", line 167, in prepare_headers
    super().prepare_headers(headers)
  File "C:\Users\USERNAME\AppData\Roaming\Python\Python312\site-packages\requests\models.py", line 490, in prepare_headers
    check_header_validity(header)
  File "C:\Users\USERNAME\AppData\Roaming\Python\Python312\site-packages\requests\utils.py", line 1042, in check_header_validity
    _validate_header_part(header, value, 1)
  File "C:\Users\USERNAME\AppData\Roaming\Python\Python312\site-packages\requests\utils.py", line 1051, in _validate_header_part
    raise InvalidHeader(
requests.exceptions.InvalidHeader: Header part (['Internet Archive Python library 5.0.1', 'Internet Archive Python library 5.0.1']) from ('x-archive-meta00-scanner', ['Internet Archive Python library 5.0.1', 'Internet Archive Python library 5.0.1']) must be of type str or bytes, not <class 'list'>
```

The error which shows is for the fact that the `scanner` request field is a list.  That comes from the field in the `metadata` variable of function `prepare_headers` also being a list.  HTTP doesn't like passing lists into the request body.

I added this code:

```patch
+ if (isinstance(metadata['scanner'], list)):
+     metadata['scanner'] = ', '.join(metadata['scanner'])
```

It de-serialises that weird `scanner` list into a comma-separated string.

---

So far, *I've only tested with Tubeup*.  **Tubeup specifies the `scanner` field as a string** (which I think is expected behaviour):

```py
metadata = dict(
    mediatype=('audio' if collection == 'opensource_audio'
               else 'movies'),
    creator=uploader,
    collection=collection,
    title=title,
    description=description,
    date=upload_date,
    year=upload_year,
    subject=tags_string,
    originalurl=videourl,
    licenseurl=licenseurl,

    # Set 'scanner' metadata pair to allow tracking of TubeUp
    # powered uploads, per request from archive.org
    scanner='TubeUp Video Stream Mirroring Application {}'.format(__version__))
```

---

With the changes I published, the following output is generated:

```
PS C:\Users\USERNAME> tubeup https://soundcloud.com/shokhi-chumoghiqael-9/lllaaala-2024-11-05 -i
[soundcloud] Original download format is only available for registered users. Use --cookies, --cookies-from-browser, --username and --password, --netrc-cmd, or --netrc (soundcloud) to provide account credentials. See  https://github.com/yt-dlp/yt-dlp/wiki/FAQ#how-do-i-pass-cookies-to-yt-dlp  for how to manually pass cookies
LƏLƏLƏAAALA (2024-11-05)
There are no annotations to write.

Downloaded C:\Users\USERNAME\.tubeup\downloads\1954371115.opus
1954371115: Possible MPEG-TS in MP4 container or malformed AAC timestamps
 uploading 1954371115.info.json:   0%|                                                                                                  | 0/1 [00:00<?, ?MiB/s]{'mediatype': 'audio', 'creator': 'VisualPlugin', 'collection': 'opensource_audio', 'title': 'LƏLƏLƏAAALA (2024-11-05)', 'description': '', 'date': '2024-11-10', 'year': '2024', 'subject': 'Soundcloud;video;', 'originalurl': 'https://soundcloud.com/shokhi-chumoghiqael-9/lllaaala-2024-11-05', 'licenseurl': None, 'scanner': 'TubeUp Video Stream Mirroring Application 2023.08.19', 'channel': 'https://soundcloud.com/shokhi-chumoghiqael-9'}
 uploading 1954371115.info.json: 100%|██████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00, 16.84MiB/s]
 uploading 1954371115.jpg:   0%|                                                                                                        | 0/1 [00:00<?, ?MiB/s]{'mediatype': 'audio', 'creator': 'VisualPlugin', 'collection': 'opensource_audio', 'title': 'LƏLƏLƏAAALA (2024-11-05)', 'description': '', 'date': '2024-11-10', 'year': '2024', 'subject': 'Soundcloud;video;', 'originalurl': 'https://soundcloud.com/shokhi-chumoghiqael-9/lllaaala-2024-11-05', 'licenseurl': None, 'scanner': 'TubeUp Video Stream Mirroring Application 2023.08.19, Internet Archive Python library 5.0.1', 'channel': 'https://soundcloud.com/shokhi-chumoghiqael-9'}
 uploading 1954371115.jpg: 100%|████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00,  7.38MiB/s]
 uploading 1954371115.opus:   0%|                                                                                                       | 0/4 [00:00<?, ?MiB/s]{'mediatype': 'audio', 'creator': 'VisualPlugin', 'collection': 'opensource_audio', 'title': 'LƏLƏLƏAAALA (2024-11-05)', 'description': '', 'date': '2024-11-10', 'year': '2024', 'subject': 'Soundcloud;video;', 'originalurl': 'https://soundcloud.com/shokhi-chumoghiqael-9/lllaaala-2024-11-05', 'licenseurl': None, 'scanner': 'TubeUp Video Stream Mirroring Application 2023.08.19, Internet Archive Python library 5.0.1, Internet Archive Python library 5.0.1', 'channel': 'https://soundcloud.com/shokhi-chumoghiqael-9'}
 uploading 1954371115.opus: 100%|███████████████████████████████████████████████████████████████████████████████████████████████| 4/4 [00:05<00:00,  1.25s/MiB]

:: Upload Finished. Item information:
Title: LƏLƏLƏAAALA (2024-11-05)
Item URL: https://archive.org/details/soundcloud-1954371115
```

---

Here's the result image for https://archive.org/details/soundcloud-1954372307:

![image](https://github.com/user-attachments/assets/c9bed944-cea6-4178-81c1-7364ed696600)
