### PR TITLE
Advanced Seach num_found bug fix

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -9,6 +9,8 @@ Release History
 **Bugfixes**
 
 - Fixed bug where some error messages mentioned the wrong arg in the message.
+- Fixed bug where Scrape API was being used for num-found,
+  even if Advanced Search was triggered via page/rows params.
 
 5.0.3 (2024-11-12)
 ++++++++++++++++++

--- a/internetarchive/__version__.py
+++ b/internetarchive/__version__.py
@@ -1,1 +1,1 @@
-__version__ = '5.0.4.dev1'
+__version__ = '5.0.4.dev2'

--- a/internetarchive/search.py
+++ b/internetarchive/search.py
@@ -228,7 +228,18 @@ class Search:
     @property
     def num_found(self):
         if not self._num_found:
-            if not self.fts:
+            if not self.fts and 'page' in self.params:
+                p = self.params.copy()
+                p['output'] = 'json'
+                r = self.session.get(self.search_url,
+                                     params=p,
+                                     auth=self.auth,
+                                     **self.request_kwargs)
+                j = r.json()
+                num_found = int(j.get('response', {}).get('numFound', 0))
+                if not self._num_found:
+                    self._num_found = num_found
+            elif not self.fts:
                 p = self.params.copy()
                 p['total_only'] = 'true'
                 r = self.session.post(self.scrape_url,


### PR DESCRIPTION
Fixed bug where Scrape API was being used for num-found, even if Advanced Search was triggered via page/rows params.