### PR TITLE
Fixes #675: itemlist is already a file-like object

### DIFF
--- a/internetarchive/cli/ia_download.py
+++ b/internetarchive/cli/ia_download.py
@@ -150,8 +150,7 @@ def main(args: argparse.Namespace, parser: argparse.ArgumentParser) -> None:
     ids: list[File | str] | Search | TextIO
 
     if args.itemlist:
-        with open(args.itemlist) as fp:
-            ids = [x.strip() for x in fp]
+        ids = [x.strip() for x in args.itemlist]
         total_ids = len(ids)
     elif args.search:
         try:


### PR DESCRIPTION
closes #675

open() is redundant in [line 153](https://github.com/jjjake/internetarchive/blob/042b1c70fd838e3cad5dc14fa3599a3d8bd627f0/internetarchive/cli/ia_download.py#L153)