### PR TITLE
Fixed typo in files.py, corrected typings for `Item.get_files` function.

### DIFF
--- a/internetarchive/files.py
+++ b/internetarchive/files.py
@@ -430,7 +430,7 @@ class File(BaseFile):
         :param verbose: (optional) Print actions to stdout.
 
         :type debug: bool
-        :param debug: (optional) Set to True to print headers to stdout and exit exit
+        :param debug: (optional) Set to True to print headers to stdout and exit
                       without sending the delete request.
 
         """

--- a/internetarchive/item.py
+++ b/internetarchive/item.py
@@ -532,8 +532,8 @@ class Item(BaseItem):
     def get_files(self,
                   files: File | list[File] | None = None,
                   formats: str | list[str] | None = None,
-                  glob_pattern: str | None = None,
-                  exclude_pattern: str | None = None,
+                  glob_pattern: str | list[str] | None = None,
+                  exclude_pattern: str | list[str] | None = None,
                   on_the_fly: bool = False):
         files = files or []
         formats = formats or []


### PR DESCRIPTION
Based on the code, both `glob_pattern` and `exclude_pattern` in `Item.get_files` should both be of type `str | list[str] | None` rather than `str | None`