### PR TITLE
Correct behavior of ia_copy to avoid dropping path prefixes, fix ia_move

### DIFF
--- a/internetarchive/cli/ia_copy.py
+++ b/internetarchive/cli/ia_copy.py
@@ -109,7 +109,7 @@ def main(args: argparse.Namespace,
 
     global SRC_ITEM
     SRC_ITEM = args.session.get_item(args.source.split("/")[0])  # type: ignore
-    SRC_FILE = SRC_ITEM.get_file(args.source.split("/")[-1])  # type: ignore
+    SRC_FILE = SRC_ITEM.get_file(args.source.split("/",1)[-1])  # type: ignore
 
     try:
         assert_src_file_exists(args.source)


### PR DESCRIPTION
src file assertion splits once (removes item prefix) but actual copy operation splits without limit, so all path prefixes including subdirs are removed

this brings the behavior of the return value in line with the assertion and fixes the ia_move behavior where moved files in subdirs are never deleted