### PR TITLE
More complete percent encoding of download path (Windows) + add a traversal guard

### DIFF
--- a/internetarchive/exceptions.py
+++ b/internetarchive/exceptions.py
@@ -54,3 +54,8 @@ class AccountAPIError(Exception):
     def __init__(self, message: str, error_data: Optional[Dict] = None):
         super().__init__(message)
         self.error_data = error_data
+
+
+class DirectoryTraversalError(Exception):
+    """Raised when a computed local file path escapes the intended destination directory."""
+    pass

--- a/internetarchive/files.py
+++ b/internetarchive/files.py
@@ -243,7 +243,37 @@ class File(BaseFile):
                 raise OSError(f'{destdir} is not a directory!')
             file_path = os.path.join(destdir, file_path)
 
+        # Windows-only local filename sanitization for invalid / reserved names.
+        # Keep original remote filename (self.name) unchanged for HTTP request.
+        # Only sanitize the final path component, not the whole provided path.
+        if os.name == 'nt' and not return_responses:
+            base_dir, base_name = os.path.split(file_path)
+            sanitized, modified = utils.sanitize_windows_filename(base_name)
+            if modified:
+                if verbose:
+                    print(f' encoding windows filename component: {base_name} -> {sanitized}', file=sys.stderr)
+                log.debug('Sanitized Windows filename component %r -> %r', base_name, sanitized)
+                file_path = os.path.join(base_dir, sanitized)
+
+        # Directory traversal guard (all platforms). Ensure target path is inside destdir (or cwd if none provided).
+        # Determine intended base directory.
+        intended_base = destdir if destdir else os.getcwd()
+        try:
+            if not utils.is_path_within_directory(intended_base, os.path.abspath(file_path)):
+                raise exceptions.DirectoryTraversalError(
+                    f'Unsafe file path resolved outside destination directory: {file_path}'
+                )
+        except AttributeError:
+            # Fallback if DirectoryTraversalError not present (older versions); re-raise generic.
+            raise OSError(f'Unsafe file path resolved outside destination directory: {file_path}')
+
         parent_dir = os.path.dirname(file_path)
+
+        # Warn (not fail) if path length may cause Windows issues (>240 chars typical safe limit)
+        if os.name == 'nt' and len(os.path.abspath(file_path)) > 240:
+            log.warning('Long path may cause issues: %s', file_path)
+            if verbose:
+                print(f' warning: long path may cause issues: {file_path}', file=sys.stderr)
 
         # Check if we should skip...
         if not return_responses and os.path.exists(file_path.encode('utf-8')):

--- a/internetarchive/item.py
+++ b/internetarchive/item.py
@@ -42,7 +42,7 @@ from requests import Request, Response
 from requests.exceptions import HTTPError
 from tqdm import tqdm
 
-from internetarchive import catalog
+from internetarchive import catalog, exceptions
 from internetarchive.auth import S3Auth
 from internetarchive.files import File
 from internetarchive.iarequest import MetadataRequest, S3Request
@@ -793,9 +793,10 @@ class Item(BaseItem):
                                no_change_timestamp, params, None, stdout, ors, timeout)
             except exceptions.DirectoryTraversalError as exc:  # type: ignore
                 # Record error and continue; do not abort entire download batch.
-                log.error(str(exc))
-                if verbose:
-                    print(f' error: {exc}', file=sys.stderr)
+                msg = f'error: {exc}'
+                log.error(msg)
+                # Always surface to stderr so user sees the skip.
+                print(f' {msg}', file=sys.stderr)
                 errors.append(f.name)
                 continue
             if return_responses:

--- a/internetarchive/utils.py
+++ b/internetarchive/utils.py
@@ -578,7 +578,9 @@ def sanitize_windows_relpath(rel_path: str, verbose: bool = False, printer=None)
     out_parts: list[str] = []
     modified_any = False
     if printer is None:
-        printer = lambda msg: None  # noqa: E731
+        def noop_printer(msg):
+            pass
+        printer = noop_printer
     original_components: list[str] = []
     for comp in components:
         original_components.append(comp)

--- a/internetarchive/utils.py
+++ b/internetarchive/utils.py
@@ -579,10 +579,14 @@ def sanitize_windows_relpath(rel_path: str, verbose: bool = False, printer=None)
     modified_any = False
     if printer is None:
         printer = lambda msg: None  # noqa: E731
+    original_components: list[str] = []
     for comp in components:
+        original_components.append(comp)
         sanitized, modified = sanitize_windows_filename(comp)
-        if modified and verbose:
-            printer(f' encoding windows filename component: {comp} -> {sanitized}')
         out_parts.append(sanitized)
         modified_any = modified_any or modified
-    return os.path.join(*out_parts), modified_any
+    result_path = os.path.join(*out_parts)
+    if verbose and modified_any:
+        original_path_display = os.path.join(*original_components)
+        printer(f'windows path sanitized: {original_path_display} -> {result_path}')
+    return result_path, modified_any

--- a/tests/test_windows_filenames.py
+++ b/tests/test_windows_filenames.py
@@ -30,14 +30,16 @@ def test_reserved_names(reserved, expected):
     assert modified
     assert sanitized == expected
 
-@pytest.mark.parametrize('filename', [
-    'AUX.txt', 'con.log', 'Com1.bin'
+@pytest.mark.parametrize('filename,expected', [
+    ('AUX.txt', 'AU%58.txt'),
+    ('con.log', 'co%6E.log'),
+    ('Com1.bin', 'Com%31.bin'),
+    ('COM3.txt.txt', 'COM%33.txt.txt'),
 ])
-def test_reserved_with_extension_allowed(filename):
+def test_reserved_with_extension_sanitized(filename, expected):
     sanitized, modified = sanitize_windows_filename(filename)
-    # Should not modify because extension present
-    assert not modified
-    assert sanitized == filename
+    assert modified
+    assert sanitized == expected
 
 @pytest.mark.parametrize('filename,expected', [
     ('name.', 'name%2E'),

--- a/tests/test_windows_filenames.py
+++ b/tests/test_windows_filenames.py
@@ -1,0 +1,98 @@
+import os
+import sys
+import pytest
+
+from internetarchive.utils import sanitize_windows_filename, is_path_within_directory
+from internetarchive.exceptions import DirectoryTraversalError
+
+IS_WIN = os.name == 'nt'
+
+pytestmark = pytest.mark.skipif(not IS_WIN, reason='Windows specific tests')
+
+def test_control_char_encoding():
+    name = 'bad\x05name'
+    sanitized, modified = sanitize_windows_filename(name)
+    assert modified
+    assert sanitized == 'bad%05name'
+
+@pytest.mark.parametrize('reserved,expected', [
+    ('AUX', 'AU%58'),
+    ('CON', 'CO%4E'),
+    ('COM1', 'COM%31'),
+    ('LPT9', 'LPT%39'),
+    ('NUL', 'NU%4C'),
+])
+def test_reserved_names(reserved, expected):
+    sanitized, modified = sanitize_windows_filename(reserved)
+    assert modified
+    assert sanitized == expected
+
+@pytest.mark.parametrize('filename', [
+    'AUX.txt', 'con.log', 'Com1.bin'
+])
+def test_reserved_with_extension_allowed(filename):
+    sanitized, modified = sanitize_windows_filename(filename)
+    # Should not modify because extension present
+    assert not modified
+    assert sanitized == filename
+
+@pytest.mark.parametrize('filename,expected', [
+    ('name.', 'name%2E'),
+    ('name..', 'name%2E%2E'),
+    ('trailspace ', 'trailspace%20'),
+    ('both. ', 'both%2E%20'),
+])
+def test_trailing_dot_space(filename, expected):
+    sanitized, modified = sanitize_windows_filename(filename)
+    assert modified
+    assert sanitized == expected
+
+@pytest.mark.parametrize('ch,enc', [
+    (':', '%3A'), ('*', '%2A'), ('<', '%3C'), ('>', '%3E'), ('|', '%7C'), ('?', '%3F'), ('\\', '%5C'), ('"', '%22')
+])
+def test_invalid_chars(ch, enc):
+    sanitized, modified = sanitize_windows_filename(f'a{ch}b')
+    assert modified
+    assert sanitized == f'a{enc}b'
+
+@pytest.mark.parametrize('name', [
+    'back\\slash', 'dir\\\\file'
+])
+def test_backslash_always_encoded(name):
+    sanitized, modified = sanitize_windows_filename(name)
+    assert '%5C' in sanitized
+
+@pytest.mark.parametrize('name', [
+    'hello%20world', '%41already'
+])
+def test_existing_percent_sequences(name):
+    # If no other encoding needed, percent remains unless part of %HH sequence and no other changes?
+    sanitized, modified = sanitize_windows_filename(name)
+    # existing sequences remain unchanged because no other encoding triggered
+    assert sanitized == name
+
+@pytest.mark.parametrize('name', [
+    'needs:encoding%20plus', 'AUX%41'  # reserved triggers change
+])
+def test_percent_gets_encoded_when_other_modifications(name):
+    sanitized, modified = sanitize_windows_filename(name)
+    if '%' in name and modified:
+        assert '%25' in sanitized or name.count('%') == sanitized.count('%25')
+
+# Directory traversal guard logic tests (cross-platform semantics validated on Windows here)
+
+def test_is_path_within_directory_true(tmp_path):
+    base = tmp_path
+    target = base / 'subdir' / 'file.txt'
+    target.parent.mkdir()
+    target.write_text('x')
+    assert is_path_within_directory(str(base), str(target))
+
+
+def test_is_path_within_directory_false(tmp_path):
+    base = tmp_path / 'a'
+    other = tmp_path / 'b' / 'file.txt'
+    base.mkdir()
+    (tmp_path / 'b').mkdir()
+    other.write_text('x')
+    assert not is_path_within_directory(str(base), str(other))


### PR DESCRIPTION
This patch does more complete percent encoding on Windows platforms, so files can still be downloaded which previously resulted in an error, or in some cases froze the console. There's also an explicit directory traversal guard added for all platforms (which should hopefully not be triggerable)

```sh
## Example of previous output (5.5.1 or 5.6.0.dev1):

> ia download test-upload-aux.txt
test-upload-aux.txt:
 downloading AUX.TXT: 27.0iB [00:00, 24.2kiB/s]
## (at this point ia freezes, and the user can't even ctrl-c)
```

## Demo

```sh
## Example output with this patch

> ia download test-upload-bad
test-upload-bad:
windows path sanitized: test-upload-bad\AUX -> test-upload-bad\AU%58
 downloading AUX: 100%|█████████████████████████████████████████| 10.0/10.0 [00:00<00:00, 8.25kiB/s]
windows path sanitized: test-upload-bad\aaa : \ | ? * > < .txt -> test-upload-bad\aaa %3A %5C %7C %3F %2A %3E %3C .txt
 downloading aaa : \ | ? * > < .txt: 100%|██████████████████████| 6.00/6.00 [00:00<00:00, 6.72kiB/s]
...

> ls .\test-upload-bad\    
...
Mode                 LastWriteTime         Length Name
----                 -------------         ------ ----
-a---          2025-09-06    10:46              6 aaa %3A %5C %7C %3F %2A %3E %3C .txt
-a---          2025-09-06    10:46             10 AU%58
...
```

# More info

I've also added a general directory traversal check to guard against such things happening in future, though hopefully there's no way to trigger it now.

For legacy reasons, files on Windows can't named certain things: `CON`, `PRN`, `AUX`, `NUL`, `LPT[1-9]`, `COM[1-9]`. This also goes for folders and includes files with extensions, e.g. in Windows 10:

```cmd
> mkdir LPT1.TXT
The directory name is invalid.
```

This patch stops these filenames freezing ia in two ways:
1. percent encodes a letter of Windows device names: AUX -> AU%58; CON -> CO%4E; COM1.txt -> COM%31.txt
2. an explicit directory traversal check, which gives an error for that file if it fails. This should error should never be reached but it's there in case. But for example, before the above percent encoding was implemented it would catch these files instead of freezing:

```sh
## Examples of directory traversal guard getting triggered in test build without percent-encoding

> ia download test-upload-aux.txt
test-upload-aux.txt:
 error: Unsafe file path resolved outside destination directory: test-upload-aux.txt\AUX.TXT
 downloading test-upload-aux.txt_archive.torrent: 100%|██████████████████████████████████████████████| 1.66k/1.66k [00:00<00:00, 2.29MiB/s]
 downloading test-upload-aux.txt_files.xml: 1.45kiB [00:00, 1.09MiB/s]
 downloading test-upload-aux.txt_meta.sqlite: 100%|██████████████████████████████████████████████████| 20.0k/20.0k [00:00<00:00, 13.9MiB/s]
 downloading test-upload-aux.txt_meta.xml: 530iB [00:00, 603kiB/s]
  
> ia download AUX.TXT        
AUX.TXT:
 error: Unsafe file path resolved outside destination directory: AUX.TXT\AUX.TXT_archive.torrent
 error: Unsafe file path resolved outside destination directory: AUX.TXT\AUX.TXT_files.xml
 error: Unsafe file path resolved outside destination directory: AUX.TXT\AUX.TXT_meta.sqlite
 error: Unsafe file path resolved outside destination directory: AUX.TXT\AUX.TXT_meta.xml
 error downloading file AUX.TXT\device-name-collisions-test.txt, exception raised: [WinError 267] The directory name is invalid: 'AUX.TXT'

## In the previous version, both of the above would cause ia to freeze.
```

As the above example shows, this sanitation is needed on identifiers too, e.g. to allow downloading of [archive.org/details/AUX.TXT](https://archive.org/details/AUX.TXT).

Files ending in dots and/or spaces are also url encoded rather than failing.

The other thing this patch has added is percent-encoding of backslashes (`\`) in filenames. On the Internet Archive they are always part of a filename and never a path separator, so when downloaded they are percent-encoded too rather than creating paths.

## Security fixes?

- Untrusted filenames matching Windows reserved devices (COM1, LPT1, etc): Low. 
- Backslash to directory separator: Low.

In the version previous to this patch, there might be some way for a malicious uploader to exploit the behavior of COM1, LPT1, etc, but it seems unlikely. The victim would have to download the malicious item while they have an exploitable device connected to one of these typically unused ports. Perhaps the attacker could print something on an attached printer, but I have not investigated closely enough to see if this is a real threat.

Backslashes in filenames of downloaded files were still treated as a directory separators, but other safeguards were put it place to prevent directory traversal in 5.5.1.

## Alternatives:

- I believe there is an API or some way on Windows which _does_ allow the creation of these reserved names (e.g. `mkdir AUX` fails but `touch AUX` succeeds). I haven't investigated how to do this in Python or in general. When such files are created, they can be a pain. e.g. It looks like you can't delete a file named `AUX` in Explorer without admin permissions. So I've gone with percent-encoding of a letter in the filename, which seems more robust than getting around the limitation another way.

## Things not done:

- I don't think the percent _decoding_ is done when uploading
- I have tested the new app version but I have not tested the actual python tests (I got a bit lost trying to work out how to run them correctly)
- I haven't done extensive testing of the >240 character length warning
- Have not done tests with various different parameters like --no-directories, --destdir, etc

## Summary:

- Allows downloading of any filename by doing more complete percent encoding (Windows)
- Adds a directory traversal guard when downloading (all platforms)
- Adds a warning when downloading files with a path > 240 characters (Windows) 

Also this resolves #595 