### PR TITLE
Add Python 3.14 to the testing

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -7,7 +7,7 @@ jobs:
       fail-fast: false
       max-parallel: 1  # Avoid timeout errors
       matrix:
-        python: ['3.9', '3.10', '3.11', '3.12', '3.13', 'pypy-3.10']
+        python: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14', 'pypy-3.11']
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-python@v6

--- a/setup.cfg
+++ b/setup.cfg
@@ -56,7 +56,7 @@ docs =
     sphinx==4.5.0
     sphinx-autodoc-typehints==1.18.1
 test =
-    pytest==7.1.2
+    pytest==8.4.2
     responses==0.20.0
     ruff==0.8.5
 types =

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,3 @@
-pytest==7.2.2
+pytest==8.4.2
 responses==0.23.1
 ruff==0.8.5

--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import re
+import sys
 import types
 from copy import deepcopy
 
@@ -36,6 +37,9 @@ EXPECTED_S3_HEADERS = {
     'accept-encoding': 'gzip, deflate',
     'connection': 'close',
 }
+# `compression.zstd` is added to the Standard Library in Python >= 3.14.
+if sys.version_info >= (3, 14):
+    EXPECTED_S3_HEADERS['accept-encoding'] += ', zstd'
 
 
 def test_get_item(nasa_metadata, nasa_item, session):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{39,310,311,312,313},pypy{310}
+envlist = py{39,310,311,312,313,314},pypy{311}
 
 [testenv]
 deps = -r tests/requirements.txt


### PR DESCRIPTION
https://www.python.org/downloads/release/python-3140/

`PyPy3.11`: https://pypy.org/download.html

---
Three failing tests because `zstd` was added to the Python >= 3.14 Standard Library
* [PEP 784](https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep784): A new module `compression.zstd` providing support for the Zstandard compression algorithm.
> {'accept-encoding': 'gzip, deflate, zstd'} != {'accept-encoding': 'gzip, deflate'}

> FAILED tests/test_item.py::test_upload - AssertionError: assert {'accept': '*...
FAILED tests/test_item.py::test_upload_metadata - AssertionError: assert {'ac...
FAILED tests/test_item.py::test_upload_queue_derive - AssertionError: assert ...