### PR TITLE
pre-commit autoupdate 2025-10-18

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-builtin-literals
       - id: check-executables-have-shebangs
@@ -21,14 +21,14 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.8.5
+    rev: v0.14.1
 
     hooks:
-      - id: ruff
+      - id: ruff-check
         # args: [ --fix, --exit-non-zero-on-fix ]
 
   - repo: https://github.com/psf/black
-    rev: 24.10.0
+    rev: 25.9.0
     hooks:
       - id: black
         language_version: python3
@@ -37,12 +37,12 @@ repos:
           - --skip-string-normalization
 
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.3.0
+    rev: v2.4.1
     hooks:
       - id: codespell  # See setup.cfg for args
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.14.1
+    rev: v1.18.2
     hooks:
       - id: mypy
         additional_dependencies:
@@ -54,6 +54,6 @@ repos:
           - types-urllib3
 
   - repo: https://github.com/asottile/setup-cfg-fmt
-    rev: v2.7.0
+    rev: v2.7.0  # Use v2.7.0 until dropping Python 3.9 support
     hooks:
       - id: setup-cfg-fmt

--- a/internetarchive/config.py
+++ b/internetarchive/config.py
@@ -162,7 +162,7 @@ def parse_config_file(config_file=None):
 
 def get_config(config=None, config_file=None) -> dict:
     _config = config or {}
-    config_file, is_xdg, config_parser = parse_config_file(config_file)
+    config_file, _is_xdg, config_parser = parse_config_file(config_file)
 
     # TODO: Use typing.TypedDict when we drop Python 3.8 support
     # to get rid of noqa: UP006

--- a/internetarchive/iarequest.py
+++ b/internetarchive/iarequest.py
@@ -338,7 +338,7 @@ def prepare_patch(metadata, source_metadata, append, expect=None,
     if isinstance(destination, dict):
         destination.update(prepared_metadata)
     elif isinstance(metadata, list):
-        destination = prepared_metadata if not destination else prepared_metadata
+        destination = prepared_metadata if not destination else prepared_metadata  # noqa: RUF034
     else:
         if isinstance(prepared_metadata, list):
             destination = prepared_metadata

--- a/internetarchive/item.py
+++ b/internetarchive/item.py
@@ -919,7 +919,7 @@ class Item(BaseItem):
     def delete_flag(
             self,
             category: str,
-            user: Optional[str] = None,  # noqa: UP007
+            user: Optional[str] = None,  # noqa: UP045
     ) -> Response:
         if user is None:
             user = f"@{self.session.config.get('general', {}).get('screenname')}"
@@ -932,7 +932,7 @@ class Item(BaseItem):
     def add_flag(
             self,
             category: str,
-            user: Optional[str] = None,  # noqa: UP007
+            user: Optional[str] = None,  # noqa: UP045
     ) -> Response:
         if user is None:
             user = f"@{self.session.config.get('general', {}).get('screenname')}"
@@ -967,7 +967,7 @@ class Item(BaseItem):
         r = self.session.post(self.urls.metadata, data=data)  # type: ignore
         return r
 
-    def upload_file(self, body,  # noqa: PLR0915; TODO: Refactor this method to reduce complexity
+    def upload_file(self, body,  # noqa: PLR0915 TODO: Refactor this method to reduce complexity
                     key: str | None = None,
                     metadata: Mapping | None = None,
                     file_metadata: Mapping | None = None,

--- a/internetarchive/session.py
+++ b/internetarchive/session.py
@@ -42,6 +42,7 @@ import requests.sessions
 from requests import Response
 from requests.adapters import HTTPAdapter
 from requests.cookies import create_cookie
+from requests.exceptions import RequestException
 from requests.utils import default_headers
 from urllib3 import Retry
 
@@ -603,7 +604,6 @@ class ArchiveSession(requests.sessions.Session):
                         insecure = True
                         break
         if insecure:
-            from requests.exceptions import RequestException
             msg = ('You are attempting to make an HTTPS request on an insecure platform,'
                    ' please see:\n\n\thttps://archive.org/services/docs/api'
                    '/internetarchive/troubleshooting.html#https-issues\n')

--- a/internetarchive/utils.py
+++ b/internetarchive/utils.py
@@ -54,7 +54,7 @@ def deep_update(d: dict, u: Mapping) -> dict:
             r = deep_update(d.get(k, {}), v)
             d[k] = r
         else:
-            d[k] = u[k]
+            d[k] = v
     return d
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -58,7 +58,7 @@ docs =
 test =
     pytest==7.1.2
     responses==0.20.0
-    ruff==0.8.5
+    ruff==0.14.1
 types =
     tqdm-stubs>=0.2.0
     types-colorama

--- a/tests/cli/test_ia_download.py
+++ b/tests/cli/test_ia_download.py
@@ -22,7 +22,7 @@ def test_dry_run():
     nasa_url = 'http://archive.org/download/nasa/'
     expected_urls = {nasa_url + f for f in NASA_EXPECTED_FILES}
 
-    stdout, stderr = call_cmd('ia --insecure download --dry-run nasa')
+    stdout, _stderr = call_cmd('ia --insecure download --dry-run nasa')
     output_lines = stdout.split('\n')
     dry_run_urls = {x.strip() for x in output_lines if x and 'nasa:' not in x}
 
@@ -59,10 +59,10 @@ def test_format(tmpdir_ch):
 def test_on_the_fly_format():
     i = 'wonderfulwizardo00baumiala'
 
-    stdout, stderr = call_cmd(f'ia --insecure download --dry-run --format="DAISY" {i}')
+    stdout, _stderr = call_cmd(f'ia --insecure download --dry-run --format="DAISY" {i}')
     assert stdout == ''
 
-    stdout, stderr = call_cmd(f'ia --insecure download --dry-run --format="DAISY" --on-the-fly {i}')
+    stdout, _stderr = call_cmd(f'ia --insecure download --dry-run --format="DAISY" --on-the-fly {i}')
     assert stdout == f'http://archive.org/download/{i}/{i}_daisy.zip'
 
 
@@ -71,7 +71,7 @@ def test_clobber(tmpdir_ch):
     call_cmd(cmd)
     assert files_downloaded('nasa') == {'nasa_meta.xml'}
 
-    stdout, stderr = call_cmd(cmd)
+    _stdout, stderr = call_cmd(cmd)
     assert files_downloaded('nasa') == {'nasa_meta.xml'}
     prefix = 'nasa:\n'.replace('\n', os.linesep)
     filepath = os.path.join('nasa', 'nasa_meta.xml')
@@ -83,7 +83,7 @@ def test_checksum(tmpdir_ch):
     call_cmd('ia --insecure download nasa nasa_meta.xml')
     assert files_downloaded('nasa') == {'nasa_meta.xml'}
 
-    stdout, stderr = call_cmd('ia --insecure download --checksum nasa nasa_meta.xml')
+    _stdout, stderr = call_cmd('ia --insecure download --checksum nasa nasa_meta.xml')
     assert files_downloaded('nasa') == {'nasa_meta.xml'}
     prefix = 'nasa:\n'.replace('\n', os.linesep)
     filepath = os.path.join('nasa', 'nasa_meta.xml')
@@ -94,7 +94,7 @@ def test_checksum_archive(tmpdir_ch):
     call_cmd('ia --insecure download nasa nasa_meta.xml')
     assert files_downloaded('nasa') == {'nasa_meta.xml'}
 
-    stdout, stderr = call_cmd('ia --insecure download --checksum-archive nasa nasa_meta.xml')
+    _stdout, stderr = call_cmd('ia --insecure download --checksum-archive nasa nasa_meta.xml')
     assert files_downloaded('nasa') == {'nasa_meta.xml'}
     prefix = 'nasa:\n'.replace('\n', os.linesep)
     filepath = os.path.join('nasa', 'nasa_meta.xml')
@@ -105,7 +105,7 @@ def test_checksum_archive(tmpdir_ch):
         filepath = os.path.join('nasa', 'nasa_meta.xml')
         assert f.read() == f'{filepath}\n'
 
-    stdout, stderr = call_cmd('ia --insecure download --checksum-archive nasa nasa_meta.xml')
+    _stdout, stderr = call_cmd('ia --insecure download --checksum-archive nasa nasa_meta.xml')
     assert files_downloaded('nasa') == {'nasa_meta.xml'}
     prefix = 'nasa:\n'.replace('\n', os.linesep)
     filepath = os.path.join('nasa', 'nasa_meta.xml')
@@ -119,7 +119,7 @@ def test_no_directories(tmpdir_ch):
 
 def test_destdir(tmpdir_ch):
     cmd = 'ia --insecure download --destdir=thisdirdoesnotexist/ nasa nasa_meta.xml'
-    stdout, stderr = call_cmd(cmd, expected_exit_code=2)
+    _stdout, stderr = call_cmd(cmd, expected_exit_code=2)
 
     assert "--destdir: 'thisdirdoesnotexist/' is not a valid directory" in stderr
 

--- a/tests/cli/test_ia_list.py
+++ b/tests/cli/test_ia_list.py
@@ -14,14 +14,14 @@ NASA_FILES = {
 
 def test_ia_list(capsys, nasa_mocker):
     ia_call(['ia', 'list', 'nasa'])
-    out, err = capsys.readouterr()
+    out, _err = capsys.readouterr()
     assert {l for l in out.split('\n') if l} == NASA_FILES
 
 
 def test_ia_list_verbose(capsys, nasa_mocker):
     ia_call(['ia', 'list', '--verbose', 'nasa'])
 
-    out, err = capsys.readouterr()
+    out, _err = capsys.readouterr()
     _nasa_files = deepcopy(NASA_FILES)
     _nasa_files.add('name')
     assert {l for l in out.split('\n') if l} == _nasa_files
@@ -30,7 +30,7 @@ def test_ia_list_verbose(capsys, nasa_mocker):
 def test_ia_list_all(capsys, nasa_mocker):
     ia_call(['ia', 'list', '--all', 'nasa'])
 
-    out, err = capsys.readouterr()
+    out, _err = capsys.readouterr()
     out = [l for l in out.split('\n') if l]
     assert len(out) == 6
     assert all(len(f.split('\t')) == 9 for f in out)
@@ -39,7 +39,7 @@ def test_ia_list_all(capsys, nasa_mocker):
 
 def test_ia_list_location(capsys, nasa_mocker):
     ia_call(['ia', 'list', '--location', '--glob', '*meta.xml', 'nasa'])
-    out, err = capsys.readouterr()
+    out, _err = capsys.readouterr()
     assert out == 'https://archive.org/download/nasa/nasa_meta.xml\n'
 
 
@@ -48,27 +48,27 @@ def test_ia_list_columns(capsys):
         rsps.add_metadata_mock('nasa')
         ia_call(['ia', 'list', '--columns', 'name,md5', '--glob', '*meta.xml', 'nasa'])
 
-    out, err = capsys.readouterr()
+    out, _err = capsys.readouterr()
     assert out == 'nasa_meta.xml\t0e339f4a29a8bc42303813cbec9243e5\n'
 
     with IaRequestsMock() as rsps:
         rsps.add_metadata_mock('nasa')
         ia_call(['ia', 'list', '--columns', 'md5', '--glob', '*meta.xml', 'nasa'])
 
-    out, err = capsys.readouterr()
+    out, _err = capsys.readouterr()
     assert out == '0e339f4a29a8bc42303813cbec9243e5\n'
 
 
 def test_ia_list_glob(capsys, nasa_mocker):
     ia_call(['ia', 'list', '--glob', '*torrent', 'nasa'])
-    out, err = capsys.readouterr()
+    out, _err = capsys.readouterr()
     assert out == 'nasa_archive.torrent\n'
 
 
 def test_ia_list_format(capsys, nasa_mocker):
     ia_call(['ia', 'list', '--format', 'Metadata', 'nasa'])
 
-    out, err = capsys.readouterr()
+    out, _err = capsys.readouterr()
     expected_output = {
         'nasa_reviews.xml',
         'nasa_files.xml',
@@ -82,5 +82,5 @@ def test_ia_list_non_existing(capsys):
         rsps.add_metadata_mock('nasa', body='{}')
         ia_call(['ia', 'list', 'nasa'], expected_exit_code=1)
 
-    out, err = capsys.readouterr()
+    out, _err = capsys.readouterr()
     assert out == ''

--- a/tests/cli/test_ia_metadata.py
+++ b/tests/cli/test_ia_metadata.py
@@ -10,19 +10,19 @@ def test_ia_metadata_exists(capsys):
     with IaRequestsMock() as rsps:
         rsps.add_metadata_mock('nasa')
         ia_call(['ia', 'metadata', '--exists', 'nasa'], expected_exit_code=0)
-        out, err = capsys.readouterr()
+        _out, err = capsys.readouterr()
         assert err == 'nasa exists\n'
         rsps.reset()
         rsps.add_metadata_mock('nasa', '{}')
         sys.argv = ['ia', 'metadata', '--exists', 'nasa']
         ia_call(['ia', 'metadata', '--exists', 'nasa'], expected_exit_code=1)
-        out, err = capsys.readouterr()
+        _out, err = capsys.readouterr()
         assert err == 'nasa does not exist\n'
 
 
 def test_ia_metadata_formats(capsys, nasa_mocker):
     ia_call(['ia', 'metadata', '--formats', 'nasa'])
-    out, err = capsys.readouterr()
+    out, _err = capsys.readouterr()
     expected_formats = {'Collection Header', 'Archive BitTorrent', 'JPEG',
                         'Metadata', ''}
     assert set(out.split('\n')) == expected_formats
@@ -36,5 +36,5 @@ def test_ia_metadata_modify(capsys):
         rsps.add_metadata_mock('nasa', body=md_rsp, method=responses.POST)
         valid_key = f'foo-{int(time())}'
         ia_call(['ia', 'metadata', 'nasa', '--modify', f'{valid_key}:test_value'])
-        out, err = capsys.readouterr()
+        _out, err = capsys.readouterr()
         assert err == 'nasa - success: https://catalogd.archive.org/log/447613301\n'

--- a/tests/cli/test_ia_search.py
+++ b/tests/cli/test_ia_search.py
@@ -21,7 +21,7 @@ def test_ia_search_itemlist(capsys):
                  match=[responses.matchers.query_param_matcher(p1)])
         ia_call(['ia', 'search', 'collection:attentionkmartshoppers', '--itemlist'])
 
-    out, err = capsys.readouterr()
+    out, _err = capsys.readouterr()
     assert len(set(out.split())) == 100
 
 
@@ -38,5 +38,5 @@ def test_ia_search_num_found(capsys):
                  match=[responses.matchers.query_param_matcher(p)])
 
         ia_call(['ia', 'search', 'collection:nasa', '--num-found'])
-    out, err = capsys.readouterr()
+    out, _err = capsys.readouterr()
     assert out == '50\n'

--- a/tests/cli/test_ia_upload.py
+++ b/tests/cli/test_ia_upload.py
@@ -33,7 +33,7 @@ def test_ia_upload_invalid_identifier(capsys, caplog):
     ia_call(['ia', '--log', 'upload', 'føø', 'test.txt'],
             expected_exit_code=2)
 
-    out, err = capsys.readouterr()
+    _out, err = capsys.readouterr()
     assert "Identifier can only contain alphanumeric" in err
 
 
@@ -44,7 +44,7 @@ def test_ia_upload_status_check(capsys):
                  content_type='application/json')
 
         ia_call(['ia', 'upload', 'nasa', '--status-check'])
-        out, err = capsys.readouterr()
+        _out, err = capsys.readouterr()
         assert 'success: nasa is accepting requests.' in err
 
         j = json.loads(STATUS_CHECK_RESPONSE)
@@ -55,7 +55,7 @@ def test_ia_upload_status_check(capsys):
                  content_type='application/json')
 
         ia_call(['ia', 'upload', 'nasa', '--status-check'], expected_exit_code=1)
-        out, err = capsys.readouterr()
+        _out, err = capsys.readouterr()
         assert ('warning: nasa is over limit, and not accepting requests. '
                 'Expect 503 SlowDown errors.') in err
 
@@ -65,7 +65,7 @@ def test_ia_upload_debug(capsys, tmpdir_ch, nasa_mocker):
         fh.write('foo')
 
     ia_call(['ia', 'upload', '--debug', 'nasa', 'test.txt'])
-    out, err = capsys.readouterr()
+    _out, err = capsys.readouterr()
     assert 'User-Agent' in err
     assert 's3.us.archive.org/nasa/test.txt' in err
     assert 'Accept:*/*' in err
@@ -95,13 +95,13 @@ def test_ia_upload_403(capsys):
                  content_type='text/plain')
         ia_call(['ia', 'upload', 'nasa', __file__], expected_exit_code=1)
 
-    out, err = capsys.readouterr()
+    _out, err = capsys.readouterr()
     assert 'error uploading test_ia_upload.py' in err
 
 
 def test_ia_upload_invalid_cmd(capsys):
     ia_call(['ia', 'upload', 'nasa', 'nofile.txt'], expected_exit_code=2)
-    out, err = capsys.readouterr()
+    _out, err = capsys.readouterr()
 
     assert "'nofile.txt' is not a valid file or directory" in err
 
@@ -111,7 +111,7 @@ def test_ia_upload_size_hint(capsys, tmpdir_ch, nasa_mocker):
         fh.write('foo')
 
     ia_call(['ia', 'upload', '--debug', '--size-hint', '30', 'nasa', 'test.txt'])
-    out, err = capsys.readouterr()
+    _out, err = capsys.readouterr()
     assert 'User-Agent' in err
     assert 's3.us.archive.org/nasa/test.txt' in err
     assert 'x-archive-size-hint:30' in err
@@ -129,7 +129,7 @@ def test_ia_upload_automatic_size_hint_files(capsys, tmpdir_ch, nasa_mocker):
         fh.write('bar')
 
     ia_call(['ia', 'upload', '--debug', 'nasa', 'foo', 'bar'])
-    out, err = capsys.readouterr()
+    _out, err = capsys.readouterr()
     assert 'x-archive-size-hint:6' in err
 
 def test_ia_upload_automatic_size_hint_dir(capsys, tmpdir_ch, nasa_mocker):
@@ -139,7 +139,7 @@ def test_ia_upload_automatic_size_hint_dir(capsys, tmpdir_ch, nasa_mocker):
         fh.write('bar')
 
     ia_call(['ia', 'upload', '--debug', 'nasa', '.'], expected_exit_code=2)
-    out, err = capsys.readouterr()
+    _out, err = capsys.readouterr()
     assert 'x-archive-size-hint:115' in err
 
 
@@ -200,7 +200,7 @@ def test_ia_upload_stdin(tmpdir_ch, caplog):
 
 def test_ia_upload_inexistent_file(tmpdir_ch, capsys, caplog):
     ia_call(['ia', 'upload', 'foo', 'test.txt'], expected_exit_code=2)
-    out, err = capsys.readouterr()
+    _out, err = capsys.readouterr()
     assert "'test.txt' is not a valid file or directory" in err
 
 
@@ -224,7 +224,7 @@ def test_ia_upload_spreadsheet(tmpdir_ch, capsys):
                  content_type='text/plain')
         ia_call(['ia', 'upload', '--spreadsheet', 'test.csv'])
 
-    out, err = capsys.readouterr()
+    _out, err = capsys.readouterr()
     assert 'uploading foo.txt' in err
     assert 'uploading bar.txt' in err
 
@@ -243,7 +243,7 @@ def test_ia_upload_spreadsheet_item_column(tmpdir_ch, capsys):
                  content_type='text/plain')
         ia_call(['ia', 'upload', '--spreadsheet', 'test.csv'])
 
-    out, err = capsys.readouterr()
+    _out, err = capsys.readouterr()
     assert 'uploading test.txt' in err
 
 
@@ -269,7 +269,7 @@ def test_ia_upload_spreadsheet_item_and_identifier_column(tmpdir_ch, capsys):
         assert 'x-archive-meta00-identifier' not in putCalls[0].request.headers
         assert 'x-archive-meta00-item' not in putCalls[0].request.headers
 
-    out, err = capsys.readouterr()
+    _out, err = capsys.readouterr()
     assert 'uploading test.txt' in err
 
 
@@ -312,7 +312,7 @@ def test_ia_upload_spreadsheet_bom(tmpdir_ch, capsys):
                  content_type='text/plain')
         ia_call(['ia', 'upload', '--spreadsheet', 'test.csv'])
 
-    out, err = capsys.readouterr()
+    _out, err = capsys.readouterr()
     assert 'uploading test.txt' in err
 
 

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,3 @@
 pytest==7.2.2
 responses==0.23.1
-ruff==0.8.5
+ruff==0.14.1

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -215,7 +215,7 @@ def _test_parse_config_file(
         if xdg_config_home is not None:
             env['XDG_CONFIG_HOME'] = xdg_config_home
         with _environ(**env):
-            config_file_path, is_xdg, config = internetarchive.config.parse_config_file(
+            config_file_path, is_xdg, _config = internetarchive.config.parse_config_file(
                 config_file=config_file_param)
 
     assert (config_file_path, is_xdg) == expected_result[0:2]

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -39,5 +39,5 @@ def test_file_download_prevents_directory_traversal(tmpdir, nasa_item):
         # Test directory traversal attempt by getting the file and calling download directly
         file_obj = nasa_item.get_file('nasa_meta.xml')
         malicious_path = os.path.join('..', 'nasa_meta.xml')
-        with pytest.raises(DirectoryTraversalError, match="outside.*directory"):
+        with pytest.raises(DirectoryTraversalError, match=r"outside.*directory"):
             file_obj.download(file_path=malicious_path, destdir=str(tmpdir))

--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -268,7 +268,7 @@ def test_download_dry_run(tmpdir, capsys, nasa_item):
         nasa_item.download(formats='Metadata', dry_run=True)
 
     expected = {'nasa_reviews.xml', 'nasa_meta.xml', 'nasa_files.xml'}
-    out, err = capsys.readouterr()
+    out, _err = capsys.readouterr()
 
     assert {x.split('/')[-1] for x in out.split('\n') if x} == expected
 
@@ -282,7 +282,7 @@ def test_download_dry_run_on_the_fly_formats(tmpdir, capsys, nasa_item):
         nasa_item.download(formats='MARCXML', on_the_fly=True, dry_run=True)
 
     expected = {'nasa_archive_marc.xml'}
-    out, err = capsys.readouterr()
+    out, _err = capsys.readouterr()
 
     assert {x.split('/')[-1] for x in out.split('\n') if x} == expected
 
@@ -296,7 +296,7 @@ def test_download_verbose(tmpdir, capsys, nasa_item):
                  body='no dest dir',
                  adding_headers=headers)
         nasa_item.download(files='nasa_meta.xml', verbose=True)
-        out, err = capsys.readouterr()
+        _out, err = capsys.readouterr()
         assert 'downloading nasa_meta.xml' in err
 
 
@@ -315,7 +315,7 @@ def test_download_dark_item(tmpdir, capsys, nasa_metadata, session):
                  status=403,
                  adding_headers={'content-length': '100'})
         _item.download(files='nasa_meta.xml', verbose=True)
-        out, err = capsys.readouterr()
+        _out, err = capsys.readouterr()
         assert 'skipping dark-item, item is dark' in err
 
 
@@ -433,7 +433,7 @@ def test_upload_503(capsys, nasa_item):
                              verbose=True)
         except Exception as exc:
             assert 'Please reduce your request rate' in str(exc)
-            out, err = capsys.readouterr()
+            _out, err = capsys.readouterr()
             assert 'warning: s3 is overloaded' in err
 
 

--- a/tests/test_windows_filenames.py
+++ b/tests/test_windows_filenames.py
@@ -76,7 +76,7 @@ def test_invalid_chars(ch, enc):
     'back\\slash', 'dir\\\\file'
 ])
 def test_backslash_always_encoded(name):
-    sanitized, modified = sanitize_windows_filename(name)
+    sanitized, _modified = sanitize_windows_filename(name)
     assert '%5C' in sanitized
 
 
@@ -131,7 +131,7 @@ def test_traversal_attempt_sanitization(attempt):
 def test_existing_percent_sequences(name):
     # If no other encoding needed, percent remains unless part of %HH sequence
     # and no other changes?
-    sanitized, modified = sanitize_windows_filename(name)
+    sanitized, _modified = sanitize_windows_filename(name)
     # existing sequences remain unchanged because no other encoding triggered
     assert sanitized == name
 


### PR DESCRIPTION
% `pre-commit autoupdate`
```
[https://github.com/pre-commit/pre-commit-hooks] updating v5.0.0 -> v6.0.0
[https://github.com/charliermarsh/ruff-pre-commit] updating v0.8.5 -> v0.14.1
[https://github.com/psf/black] updating 24.10.0 -> 25.9.0
[https://github.com/codespell-project/codespell] updating v2.3.0 -> v2.4.1
[https://github.com/pre-commit/mirrors-mypy] updating v1.14.1 -> v1.18.2
[https://github.com/asottile/setup-cfg-fmt] updating v2.7.0 -> v3.1.0 
## reverted 'setup-cfg-fmt' upgrade because it forces dropping support for Python 3.9!
```
% `pre-commit run --all-files`

* https://github.com/astral-sh/ruff/releases 

To be fixed is a separate pull request.
* https://github.com/jjjake/internetarchive/commit/bf339f0c01cb7d4b1a36ad83d4efcc4c217dc07d#r168187610
