### PR TITLE
Remove redundant and overly broad client-side guard for delete

### DIFF
--- a/internetarchive/cli/ia_delete.py
+++ b/internetarchive/cli/ia_delete.py
@@ -23,6 +23,7 @@ import argparse
 import sys
 
 import requests.exceptions
+from requests.exceptions import HTTPError
 
 from internetarchive.cli.cli_utils import (
     FlattenListAction,
@@ -143,6 +144,13 @@ def delete_files(files, args, item, verbose):
         except requests.exceptions.RetryError:
             print(f" error: max retries exceeded for {f.name}", file=sys.stderr)
             errors = True
+            continue
+        except HTTPError as exc:
+            errors = True
+            msg = get_s3_xml_text(exc.response.content)
+            if not msg or msg == str(exc.response.content):
+                msg = str(exc)
+            print(f" error: {msg} ({exc.response.status_code})", file=sys.stderr)
             continue
 
         if resp.status_code != 204:


### PR DESCRIPTION
The local guard prevents deletion of any files with the named suffices, which is unnecessarily broad and is prevented by IAS3 in the appropriate circumstances regardless (which will also return a helpful error message instead of silently doing nothing)

This also (indirectly) fixes a typo causing inadvertent concatenation of suffices