### PR TITLE
Add global user agent setting feature

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,11 +8,16 @@ Release History
 
 **Features and Improvements**
 
-- Added support for setting a custom global User-Agent string via:
+- Added support for appending a custom suffix to the User-Agent string.
+  The default User-Agent (including access key) is always sent to ensure
+  proper request tracking.
 
-  - CLI: ``ia --user-agent "MyApp/1.0" <command>``
-  - Config file: ``user_agent = MyApp/1.0`` in ``[general]`` section
-  - Python API: ``get_session(config={'general': {'user_agent': 'MyApp/1.0'}})``
+  Example: With ``user_agent_suffix = MyApp/1.0``, the full User-Agent becomes:
+  ``internetarchive/5.7.2 (Darwin x86_64; N; en; ACCESS_KEY) Python/3.9.0 MyApp/1.0``
+
+  - CLI: ``ia --user-agent-suffix "MyApp/1.0" <command>``
+  - Config file: ``user_agent_suffix = MyApp/1.0`` in ``[general]`` section
+  - Python API: ``get_session(config={'general': {'user_agent_suffix': 'MyApp/1.0'}})``
 
 **Bugfixes**
 

--- a/internetarchive/api.py
+++ b/internetarchive/api.py
@@ -51,7 +51,8 @@ def get_session(
     :param config: A dictionary used to configure your session. Supports the following
                    keys in the ``general`` section:
 
-                   - ``user_agent``: Custom User-Agent string for all requests.
+                   - ``user_agent_suffix``: Custom string to append to the default
+                     User-Agent. The default (including access key) is always sent.
                    - ``secure``: Use HTTPS (default: True).
                    - ``host``: Host to connect to (default: archive.org).
 
@@ -72,12 +73,12 @@ def get_session(
         >>> s.access_key
         'foo'
 
-        Set a custom User-Agent:
+        Append a custom User-Agent suffix:
 
-        >>> config = {'general': {'user_agent': 'MyApp/1.0'}}
+        >>> config = {'general': {'user_agent_suffix': 'MyApp/1.0'}}
         >>> s = get_session(config)
         >>> s.headers['User-Agent']
-        'MyApp/1.0'
+        'internetarchive/5.7.2 (Darwin x86_64; N; en; ACCESS_KEY) Python/3.9.0 MyApp/1.0'
 
     From the session object, you can access all of the functionality of the
     ``internetarchive`` lib:

--- a/internetarchive/cli/ia.py
+++ b/internetarchive/cli/ia.py
@@ -100,10 +100,11 @@ def main():
                         action="store",
                         help=("host to connect to "
                               "(doesn't work for requests made to s3.us.archive.org)"))
-    parser.add_argument("--user-agent",
+    parser.add_argument("--user-agent-suffix",
                         action="store",
                         metavar="STRING",
-                        help="custom User-Agent string for all requests")
+                        help="custom string to append to the default User-Agent "
+                             "(default with access key is always included)")
 
     subparsers = parser.add_subparsers(title="commands",
                                        dest="command",
@@ -141,11 +142,11 @@ def main():
             config["general"]["host"] = args.host
         else:
             config["general"] = {"host": args.host}
-    if args.user_agent:
+    if args.user_agent_suffix:
         if config.get("general"):
-            config["general"]["user_agent"] = args.user_agent
+            config["general"]["user_agent_suffix"] = args.user_agent_suffix
         else:
-            config["general"] = {"user_agent": args.user_agent}
+            config["general"] = {"user_agent_suffix": args.user_agent_suffix}
 
     args.session = get_session(config_file=args.config_file,
                                config=config,

--- a/internetarchive/session.py
+++ b/internetarchive/session.py
@@ -87,7 +87,8 @@ class ArchiveSession(requests.sessions.Session):
                        :class:`ArchiveSession <ArchiveSession>` object.
                        Supports the following keys in the ``general`` section:
 
-                       - ``user_agent``: Custom User-Agent string for all requests.
+                       - ``user_agent_suffix``: Custom string to append to the default
+                         User-Agent. The default (including access key) is always sent.
                        - ``secure``: Use HTTPS (default: True).
                        - ``host``: Host to connect to (default: archive.org).
 
@@ -131,11 +132,12 @@ class ArchiveSession(requests.sessions.Session):
         self.http_adapter_kwargs: MutableMapping = http_adapter_kwargs or {}
 
         self.headers = default_headers()  # type: ignore[assignment]
-        custom_user_agent = self.config.get('general', {}).get('user_agent')
-        if custom_user_agent:
-            self.headers.update({'User-Agent': custom_user_agent})
+        default_user_agent = self._get_user_agent_string()
+        user_agent_suffix = self.config.get('general', {}).get('user_agent_suffix')
+        if user_agent_suffix:
+            self.headers.update({'User-Agent': f'{default_user_agent} {user_agent_suffix}'})
         else:
-            self.headers.update({'User-Agent': self._get_user_agent_string()})
+            self.headers.update({'User-Agent': default_user_agent})
         self.headers.update({'Connection': 'close'})
 
         self.mount_http_adapter()

--- a/tests/cli/test_ia.py
+++ b/tests/cli/test_ia.py
@@ -13,12 +13,14 @@ def test_ia(capsys):
     assert "invalid choice: 'nocmd'" in err
 
 
-def test_user_agent_option():
-    """Test that --user-agent option sets the User-Agent header."""
-    custom_ua = 'TestCLIAgent/1.0'
+def test_user_agent_suffix_option():
+    """Test that --user-agent-suffix option appends to the default User-Agent."""
+    custom_suffix = 'TestCLIAgent/1.0'
 
     with IaRequestsMock() as rsps:
         rsps.add_metadata_mock('nasa')
-        ia_call(['ia', '--user-agent', custom_ua, 'metadata', 'nasa'])
-        # Check that our custom user agent was sent in the request
-        assert rsps.calls[0].request.headers['User-Agent'] == custom_ua
+        ia_call(['ia', '--user-agent-suffix', custom_suffix, 'metadata', 'nasa'])
+        # Check that the user agent starts with default and ends with custom suffix
+        ua = rsps.calls[0].request.headers['User-Agent']
+        assert ua.startswith('internetarchive/')
+        assert ua.endswith(custom_suffix)

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -124,20 +124,24 @@ def test_s3_is_overloaded():
         assert r is True
 
 
-def test_custom_user_agent():
-    """Test that a custom user agent can be set via config."""
-    custom_ua = 'MyCustomApp/1.0 (test bot)'
+def test_user_agent_suffix():
+    """Test that a custom user agent suffix is appended to the default UA."""
+    custom_suffix = 'MyCustomApp/1.0 (test bot)'
     config = {
         's3': {
             'access': 'test_access',
             'secret': 'test_secret',
         },
         'general': {
-            'user_agent': custom_ua,
+            'user_agent_suffix': custom_suffix,
         },
     }
     s = internetarchive.session.ArchiveSession(config)
-    assert s.headers['User-Agent'] == custom_ua
+    # Verify the UA starts with the default and ends with the custom suffix
+    assert s.headers['User-Agent'].startswith(f'internetarchive/{__version__}')
+    assert s.headers['User-Agent'].endswith(custom_suffix)
+    # Verify access key is present in the UA
+    assert 'test_access' in s.headers['User-Agent']
 
 
 def test_default_user_agent_when_not_specified():
@@ -152,16 +156,16 @@ def test_default_user_agent_when_not_specified():
     assert s.headers['user-agent'].startswith(f'internetarchive/{__version__}')
 
 
-def test_custom_user_agent_in_requests():
-    """Test that the custom user agent is actually sent in requests."""
-    custom_ua = 'TestAgent/2.0'
+def test_user_agent_suffix_in_requests():
+    """Test that the user agent suffix is appended and sent in requests."""
+    custom_suffix = 'TestAgent/2.0'
     config = {
         's3': {
             'access': 'test_access',
             'secret': 'test_secret',
         },
         'general': {
-            'user_agent': custom_ua,
+            'user_agent_suffix': custom_suffix,
         },
     }
 
@@ -169,7 +173,24 @@ def test_custom_user_agent_in_requests():
         rsps.add(responses.GET, f'{PROTOCOL}//archive.org')
         s = internetarchive.session.ArchiveSession(config)
         r = s.get(f'{PROTOCOL}//archive.org')
-        assert r.request.headers['User-Agent'] == custom_ua
+        # Verify the UA starts with the default and ends with the custom suffix
+        assert r.request.headers['User-Agent'].startswith(f'internetarchive/{__version__}')
+        assert r.request.headers['User-Agent'].endswith(custom_suffix)
+        # Verify access key is present in the UA
+        assert 'test_access' in r.request.headers['User-Agent']
+
+
+def test_access_key_always_in_user_agent():
+    """Test that the access key is always present in the User-Agent."""
+    config = {
+        's3': {
+            'access': 'MY_ACCESS_KEY',
+            'secret': 'test_secret',
+        },
+    }
+    s = internetarchive.session.ArchiveSession(config)
+    assert 'MY_ACCESS_KEY' in s.headers['User-Agent']
+    assert s.headers['User-Agent'].startswith(f'internetarchive/{__version__}')
 
 
 def test_cookies():


### PR DESCRIPTION
Add support for setting a custom global User-Agent string via:
- CLI: `ia --user-agent "MyApp/1.0" <command>`
- Config file: `user_agent = MyApp/1.0` in `[general]` section
- Python API: `get_session(config={'general': {'user_agent': 'MyApp/1.0'}})`