### PR TITLE
Stop sending cookies on HTTP requests

### DIFF
--- a/internetarchive/session.py
+++ b/internetarchive/session.py
@@ -43,7 +43,6 @@ import requests
 import requests.sessions
 from requests import Response
 from requests.adapters import HTTPAdapter
-from requests.cookies import create_cookie
 from requests.exceptions import RequestException
 from requests.utils import default_headers
 from urllib3 import Retry
@@ -52,7 +51,7 @@ from internetarchive import __version__, auth, catalog
 from internetarchive.config import get_config
 from internetarchive.item import Collection, Item
 from internetarchive.search import Search
-from internetarchive.utils import parse_dict_cookies, reraise_modify
+from internetarchive.utils import reraise_modify
 
 logger = logging.getLogger(__name__)
 
@@ -111,15 +110,6 @@ class ArchiveSession(requests.sessions.Session):
 
         self.config = get_config(config, config_file)
         self.config_file = config_file
-        for ck, cv in self.config.get('cookies', {}).items():
-            raw_cookie = f'{ck}={cv}'
-            cookie_dict = parse_dict_cookies(raw_cookie)
-            if not cookie_dict.get(ck):
-                continue
-            cookie = create_cookie(ck, cookie_dict[ck],
-                                   domain=cookie_dict.get('domain', '.archive.org'),
-                                   path=cookie_dict.get('path', '/'))
-            self.cookies.set_cookie(cookie)
 
         self.secure: bool = self.config.get('general', {}).get('secure', True)
         self.host: str = self.config.get('general', {}).get('host', 'archive.org')

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -34,7 +34,7 @@ def test_archive_session(tmpdir):
     assert os.path.isfile('test.log')
 
     assert CONFIG == s.config
-    assert set(s.cookies.keys()) == set(CONFIG['cookies'].keys())
+    assert len(s.cookies) == 0
     assert s.secure is True
     assert s.protocol == PROTOCOL
     assert s.access_key == 'test_access'
@@ -193,21 +193,10 @@ def test_access_key_always_in_user_agent():
     assert s.headers['User-Agent'].startswith(f'internetarchive/{__version__}')
 
 
-def test_cookies():
+def test_cookies_not_sent():
+    """Cookies from config are not loaded into the session cookie jar."""
     with responses.RequestsMock() as rsps:
         rsps.add(responses.GET, f'{PROTOCOL}//archive.org')
         s = internetarchive.session.ArchiveSession(CONFIG)
         r = s.get(f'{PROTOCOL}//archive.org')
-        assert 'logged-in-sig' in r.request.headers['Cookie']
-        assert 'logged-in-user' in r.request.headers['Cookie']
-        for c in s.cookies:
-            if c.name.startswith('logged-in-'):
-                assert c.domain == '.archive.org'
-
-    with responses.RequestsMock() as rsps:
-        rsps.add(responses.GET, f'{PROTOCOL}//example.com')
-        s = internetarchive.session.ArchiveSession(CONFIG)
-        r = s.get(f'{PROTOCOL}//example.com')
-        assert 'logged-in-sig' not in r.request.headers.get('Cookie', '')
-        assert 'logged-in-user' not in r.request.headers.get('Cookie', '')
-        assert '.archive.org' not in r.request.headers.get('Cookie', '')
+        assert 'Cookie' not in r.request.headers


### PR DESCRIPTION
## Summary

- Stop loading `logged-in-user` and `logged-in-sig` cookies into the `requests.Session` cookie jar in `ArchiveSession.__init__`
- All auth uses `S3Auth` (`Authorization: LOW` header) — cookies were vestigial and sent on every `*.archive.org` request unnecessarily
- Cookie values remain in `self.config['cookies']` for `self.user_email` and `ia configure --print-cookies`

## Test plan

- [x] `ruff check` passes
- [x] `pytest` — 251 passed, 0 failures
- [ ] Manual: run redirect auth test script to confirm cookies show `NONE` on all hops

🤖 Generated with [Claude Code](https://claude.com/claude-code)