### PR TITLE
docs: correct default `ia.ini` location

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -22,10 +22,14 @@ To automatically create a config file with your archive.org credentials, you can
     Email address: user@example.com
     Password:
 
-    Config saved to: /home/user/.config/ia.ini
+    Config saved to: /home/user/.config/internetarchive/ia.ini
 
-Your config file will be saved to ``$HOME/.config/ia.ini``, or ``$HOME/.ia`` if you do not have a ``.config`` directory in ``$HOME``.
-Alternatively, you can specify your own path to save the config to via ``ia --config-file '~/.ia-custom-config' configure``.
+By default, your config file will be saved to ``$XDG_CONFIG_HOME/internetarchive/ia.ini``.
+If ``XDG_CONFIG_HOME`` is not set or is not an absolute path, ``ia`` uses ``$HOME/.config/internetarchive/ia.ini``.
+On Windows, this typically expands to a path such as ``C:\Users\<username>\.config\internetarchive\ia.ini``.
+
+For compatibility with older installations, ``ia`` also checks for existing config files at ``$HOME/.config/ia.ini`` and ``$HOME/.ia``.
+Alternatively, you can specify your own path to save the config to via ``ia --config-file '~/.ia-custom-config' configure`` or the ``IA_CONFIG_FILE`` environment variable.
 
 If you have a netrc file with your archive.org credentials in it, you can simply run ``ia configure --netrc``.
 

--- a/docs/source/python-lib.rst
+++ b/docs/source/python-lib.rst
@@ -37,7 +37,7 @@ For more control and to persist configuration across operations, use a :class:`~
     from internetarchive import get_session
 
     # Create a session with your configuration
-    session = get_session(config_file='~/.config/ia.ini')
+    session = get_session(config_file='~/.config/internetarchive/ia.ini')
 
     # Use the session for all operations
     item = session.get_item('TripDown1905')
@@ -78,7 +78,7 @@ Creating a session:
     from internetarchive import get_session
 
     # From config file
-    session = get_session(config_file='~/.config/ia.ini')
+    session = get_session(config_file='~/.config/internetarchive/ia.ini')
 
     # From dictionary
     config = {

--- a/docs/source/troubleshooting.rst
+++ b/docs/source/troubleshooting.rst
@@ -9,7 +9,7 @@ HTTPS Issues
 The ``internetarchive`` library uses the HTTPS protocol for making secure requests by default.
 If you run into problems with this, you can use HTTP to make insecure requests in one of the following ways:
 
-    + Adding the following lines to your ``ia.ini`` config file (usually located at ``~/.config/ia.ini`` or ``~/.ia.ini``):
+    + Adding the following lines to your ``ia.ini`` config file (usually located at ``~/.config/internetarchive/ia.ini``; older installations may use ``~/.config/ia.ini`` or ``~/.ia``):
 
         .. code:: bash
 

--- a/internetarchive/config.py
+++ b/internetarchive/config.py
@@ -202,7 +202,10 @@ def get_config(config=None, config_file=None) -> dict:
     """Get the merged configuration from file, environment, and provided config.
 
     Configuration is loaded in the following order (later sources override earlier):
-    1. Config file (``~/.config/internetarchive/ia.ini`` or ``~/.ia``)
+    1. Config file selected by :func:`parse_config_file`
+       (defaults to ``$XDG_CONFIG_HOME/internetarchive/ia.ini`` or
+       ``~/.config/internetarchive/ia.ini`` if ``XDG_CONFIG_HOME`` is unset;
+       legacy paths ``~/.config/ia.ini`` and ``~/.ia`` are also checked)
     2. Environment variables (``IA_ACCESS_KEY_ID``, ``IA_SECRET_ACCESS_KEY``)
     3. Provided ``config`` dict
 


### PR DESCRIPTION
## Summary

Updates documentation for the default `ia.ini` config path.

## Changes

- Document `~/.config/internetarchive/ia.ini` as the default path when `XDG_CONFIG_HOME` is unset or invalid.
- Document `$XDG_CONFIG_HOME/internetarchive/ia.ini` when `XDG_CONFIG_HOME` is set to an absolute path.
- Mention the Windows example path.
- Clarify that `~/.config/ia.ini` and `~/.ia` remain legacy fallback paths.
- Update Python usage examples that referenced `~/.config/ia.ini`.
- Update the `get_config` docstring so the `config_file` parameter refers to the path selected by `parse_config_file`.

## Validation

- Not run locally. Documentation-only change.

Closes #765.