### PR TITLE
Restore append_list dedup lost in d788e9f refactor

### DIFF
--- a/internetarchive/iarequest.py
+++ b/internetarchive/iarequest.py
@@ -521,7 +521,8 @@ def _process_non_indexed_keys(metadata, source, prepared, append, append_list):
             existing = source[current_key]
             if not isinstance(existing, list):
                 existing = [existing]
-            prepared[current_key] = existing + [value]
+            if value not in existing:
+                prepared[current_key] = existing + [value]
         elif append and source.get(current_key):
             if isinstance(source[current_key], list):
                 raise ValueError(

--- a/tests/test_iarequest.py
+++ b/tests/test_iarequest.py
@@ -256,6 +256,14 @@ def test_prepare_metadata_append_list():
     assert result["tags"] == ["foo", ["bar"]]
 
 
+def test_prepare_metadata_append_list_dedup():
+    """append_list=True should not add a value already in the list."""
+    source = {"subject": ["Math", "Science"]}
+    metadata = {"subject": "Science"}
+    result = prepare_metadata(metadata, source_metadata=source, append_list=True)
+    assert result == {}
+
+
 @pytest.mark.parametrize(("metadata", "source", "insert", "expected"), [
     # Multiple REMOVE_TAGs interleaved with inserts
     ({"tags[0]": "REMOVE_TAG", "tags[2]": "new", "tags[1]": "REMOVE_TAG"},


### PR DESCRIPTION
The `prepare_metadata` refactor in d788e9f dropped the duplicate check when appending to list fields via `append_list=True`.  Repeated `modify_metadata` calls with `append_list=True` would accumulate duplicate values. This restores the original pre-refactor behavior: skip appending if the value is already present in the list.