### PR TITLE
Strip whitespace from semicolon-delimited subjects in --remove

### DIFF
--- a/internetarchive/cli/ia_metadata.py
+++ b/internetarchive/cli/ia_metadata.py
@@ -220,7 +220,7 @@ def remove_metadata(item: item.Item,
         if not isinstance(src_md, list):
             if key == "subject":
                 if isinstance(src_md, str):
-                    src_md = src_md.split(";")
+                    src_md = [v.strip() for v in src_md.split(";")]
             elif key == "collection":
                 print(f"{item.identifier} - error: all collections would be removed, "
                       "not submitting task.", file=sys.stderr)

--- a/tests/cli/test_ia_metadata.py
+++ b/tests/cli/test_ia_metadata.py
@@ -38,3 +38,13 @@ def test_ia_metadata_modify(capsys):
         ia_call(['ia', 'metadata', 'nasa', '--modify', f'{valid_key}:test_value'])
         _out, err = capsys.readouterr()
         assert err == 'nasa - success: https://catalogd.archive.org/log/447613301\n'
+
+def test_subject_semicolon_split_strips_whitespace(capsys):
+    md_rsp = '{"success":true,"task_id":1,"log":"https://catalogd.archive.org/log/1"}'
+    nasa_body = '{"metadata":{"subject":"foo; bar; baz"},"files":[]}'
+    with IaRequestsMock() as rsps:
+        rsps.add_metadata_mock('nasa', body=nasa_body, method=responses.GET)
+        rsps.add_metadata_mock('nasa', body=md_rsp, method=responses.POST)
+        ia_call(['ia', 'metadata', 'nasa', '--remove', 'subject:bar'])
+        _out, err = capsys.readouterr()
+        assert 'success' in err


### PR DESCRIPTION
Subjects stored as `"foo; bar; baz"` get split on `;` into `[" bar", " baz"]` with leading spaces. `--remove subject:bar` fails to match `" bar"`, producing a spurious "nothing needed to be removed" warning. Fix: strip whitespace after splitting on `;`.