### PR TITLE
docs: link CLI to canonical Collections docs; fix get_config docstring

### DIFF
--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -15,7 +15,7 @@ If you're not sure where to start, most users start with these commands:
 - ``ia download <identifier>`` - :ref:`Download <cli-download>` files or items
 - ``ia search '<query>'`` - :ref:`Search <cli-search>` items on archive.org
 - ``ia metadata <identifier>`` - :ref:`Read Metadata <cli-metadata>` from an item
-- ``ia upload <identifier> <files> -m 'collection:test_collection'`` - :ref:`Upload <cli-upload>` files to archive.org
+- ``ia upload <identifier> <files> -m 'collection:test_collection'`` - :ref:`Upload <cli-upload>` files to archive.org. See `Collections <https://archive.org/developers/items.html#collections>`_ for picking a collection — ``test_collection`` is the sandbox.
 
 Check out the help menu to see all available commands:
 
@@ -165,7 +165,7 @@ Upload
 
     $ ia upload <identifier> file1 file2 --metadata="mediatype:texts" --metadata="blah:arg"
 
-.. warning:: Please note that, unless specified otherwise, items will be uploaded with a ``data`` mediatype. **This cannot be changed afterwards.** Therefore, you should specify a mediatype when uploading, eg. ``--metadata="mediatype:movies"``. Similarly, if you want your upload to end up somewhere else than the default collection (currently `community texts <//archive.org/details/opensource>`_), you should also specify a collection with ``--metadata="collection:foo"``. See `metadata documentation <//archive.org/services/docs/api/metadata-schema>`_ for more information.
+.. warning:: Please note that, unless specified otherwise, items will be uploaded with a ``data`` mediatype. **This cannot be changed afterwards.** Therefore, you should specify a mediatype when uploading, eg. ``--metadata="mediatype:movies"``. Items also default to the `opensource <https://archive.org/details/opensource>`_ (Community Texts) collection. To choose a different collection — including the other community collections, the ``test_collection`` sandbox, or a permanent collection — see `Collections <https://archive.org/developers/items.html#collections>`_ in the IA developer docs.
 
 You can upload files from ``stdin``:
 

--- a/internetarchive/config.py
+++ b/internetarchive/config.py
@@ -202,11 +202,14 @@ def get_config(config=None, config_file=None) -> dict:
     """Get the merged configuration from file, environment, and provided config.
 
     Configuration is loaded in the following order (later sources override earlier):
+
     1. Config file selected by :func:`parse_config_file`
        (defaults to ``$XDG_CONFIG_HOME/internetarchive/ia.ini`` or
        ``~/.config/internetarchive/ia.ini`` if ``XDG_CONFIG_HOME`` is unset;
        legacy paths ``~/.config/ia.ini`` and ``~/.ia`` are also checked)
+
     2. Environment variables (``IA_ACCESS_KEY_ID``, ``IA_SECRET_ACCESS_KEY``)
+
     3. Provided ``config`` dict
 
     :param config: Optional dict to merge with file/environment config.


### PR DESCRIPTION
## Summary
Two small docs fixes against `master`:

1. **`cli.rst`** — replace two inline policy mentions of `test_collection` / "default collection" with link-outs to the canonical Collections write-up at https://archive.org/developers/items.html#collections. Single source of truth: if community collections / retention window / permanent-collection process ever change, only the IA developer docs need updating; this file just links.
2. **`internetarchive/config.py` `get_config()` docstring** — add missing blank lines around the enumerated list. Without them, docutils mis-parses the list and Sphinx autodoc builds (e.g. archive.org/developers) emit an ERROR ("Unexpected indentation") and a WARNING ("Block quote ends without a blank line; unexpected unindent") for every build.

## Background
- `cli.rst` Quick Start bullet used `collection:test_collection` as an example with no warning that items there are auto-removed after ~30 days; the Upload section's warning correctly identified `opensource` as the default but enumerated no alternatives.
- The `get_config` docstring warnings have been emitting on the apidocs deploy box (`docs-automation`) on every `make publish` run.

## Changes
- **Quick Start bullet (`docs/source/cli.rst:18`)** — adds a one-sentence link plus the word "sandbox" so a reader doesn't follow the example literally and lose their upload.
- **Upload warning (`docs/source/cli.rst:168`)** — keeps the `data`-mediatype gotcha verbatim; replaces the collection-choice sentence with a link to the IA developer docs Collections section.
- **`get_config` docstring (`internetarchive/config.py:204`-ish)** — adds blank lines before the list and between items 1/2/3. No rendered-output change; the docutils warnings just go away.

## Cross-reference
- https://git.archive.org/ia/apidocs/-/merge_requests/55 — the apidocs MR that landed the canonical Collections write-up (six community collection identifiers, sandbox semantics, and the permanent-collection ask) that this PR now links to.

## Test plan
- [ ] After merge, in `ia/apidocs`: run `./download-external-docs.sh && cd docs && make html`; confirm:
  - `_build/html/internetarchive/cli.html` Quick Start bullet and Upload warning both link to `archive.org/developers/items.html#collections`
  - The two `internetarchive.config.get_config` docutils messages no longer appear in the build output