### PR TITLE
download: default cnt=0 to exclude downloads from view counts

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,6 +8,11 @@ Release History
 
 **Features and Improvements**
 
+- ``ia download`` and ``File.download()`` now send ``cnt=0`` by default,
+  so downloads no longer count toward archive.org view counts. Pass
+  ``--count-views`` (CLI) or ``count_views=True`` (library) to opt back
+  into counting; the parameter is omitted from the request entirely in
+  that case.
 - ``ia download``, ``ia delete``, and ``ia list`` now accept ``--glob``
   and ``--exclude`` flags multiple times in addition to the existing
   pipe-separated form. ``--glob "*.mp4" --glob "*.xml"`` is now

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -18,7 +18,10 @@ Release History
   and ``--exclude`` flags multiple times in addition to the existing
   pipe-separated form. ``--glob "*.mp4" --glob "*.xml"`` is now
   equivalent to ``--glob "*.mp4|*.xml"``, and the two forms can be
-  mixed.
+  mixed. ``Item.get_files()`` also pipe-splits list-element patterns
+  for ``glob_pattern`` and ``exclude_pattern``, so callers can pass
+  mixed forms like ``glob_pattern=['*.mp4|*.xml', '*.jpg']``
+  (`#769 <https://github.com/jjjake/internetarchive/pull/769>`_).
 
 **Bugfixes**
 
@@ -33,9 +36,18 @@ Release History
   subjects with leading whitespace (e.g. ``"foo; bar; baz"`` split into
   ``[" bar", " baz"]``). Values are now stripped after splitting
   (`#768 <https://github.com/jjjake/internetarchive/pull/768>`_).
-- ``Item.get_files()`` now pipe-splits list-element patterns for
-  ``glob_pattern`` and ``exclude_pattern``, so callers can pass
-  mixed forms like ``glob_pattern=['*.mp4|*.xml', '*.jpg']``.
+
+**Documentation**
+
+- Corrected default ``ia.ini`` config path in docs, thanks to
+  `@bkjoh <https://github.com/bkjoh>`_
+  (`#766 <https://github.com/jjjake/internetarchive/pull/766>`_).
+- Fixed Installation page rendering bugs
+  (`#770 <https://github.com/jjjake/internetarchive/pull/770>`_).
+- Fixed Sphinx render warnings in the ``get_config`` docstring.
+- Linked the CLI Quick Start and Upload warning to the canonical
+  Collections docs
+  (`#772 <https://github.com/jjjake/internetarchive/pull/772>`_).
 
 5.8.0 (2026-02-18)
 ++++++++++++++++++

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,11 +8,12 @@ Release History
 
 **Features and Improvements**
 
-- ``ia download`` and ``File.download()`` now send ``cnt=0`` by default,
-  so downloads no longer count toward archive.org view counts. Pass
-  ``--count-views`` (CLI) or ``count_views=True`` (library) to opt back
-  into counting; the parameter is omitted from the request entirely in
-  that case.
+- **Behavior change:** ``ia download``, ``Item.download()``,
+  ``File.download()``, and the top-level ``internetarchive.download()``
+  now send ``cnt=0`` by default, so downloads no longer count toward
+  archive.org view counts. Pass ``--count-views`` (CLI) or
+  ``count_views=True`` (library) to opt back in; the parameter is
+  omitted from the request entirely in that case.
 - ``ia download``, ``ia delete``, and ``ia list`` now accept ``--glob``
   and ``--exclude`` flags multiple times in addition to the existing
   pipe-separated form. ``--glob "*.mp4" --glob "*.xml"`` is now

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -299,6 +299,16 @@ Download from an itemlist:
 
     $ ia download --itemlist itemlist.txt
 
+.. note::
+
+    Downloads issued by ``ia download`` send ``cnt=0`` by default, so
+    they do not count toward archive.org view counts. To count a
+    download as a view, add ``--count-views``:
+
+    .. code:: console
+
+        $ ia download TripDown1905 --count-views
+
 See ``ia download --help`` for more details.
 
 

--- a/docs/source/python-lib.rst
+++ b/docs/source/python-lib.rst
@@ -44,6 +44,13 @@ For more control and to persist configuration across operations, use a :class:`~
     item.download()
     search = session.search_items('subject:science')
 
+.. note::
+
+    Downloads send ``cnt=0`` by default and do not count toward
+    archive.org view counts. To count a download as a view, pass
+    ``count_views=True`` to :func:`internetarchive.download`,
+    :meth:`Item.download`, or :meth:`File.download`.
+
 Simple Functional Interface
 ---------------------------
 

--- a/internetarchive/__version__.py
+++ b/internetarchive/__version__.py
@@ -1,1 +1,1 @@
-__version__ = '5.9.0.dev1'
+__version__ = '5.9.0.dev2'

--- a/internetarchive/api.py
+++ b/internetarchive/api.py
@@ -332,6 +332,7 @@ def download(
     return_responses: bool = False,
     no_change_timestamp: bool = False,
     timeout: float | tuple[int, float] | None = None,
+    count_views: bool = False,
     **get_item_kwargs,
 ) -> list[requests.Request | requests.Response]:
     r"""Download files from an item.
@@ -379,6 +380,9 @@ def download(
     :param return_responses: Rather than downloading files to disk, return
                              a list of response objects.
 
+    :param count_views: If True, omit the default ``cnt=0`` parameter so
+                        downloads count toward archive.org view counts.
+
     :param \*\*kwargs: Optional arguments that ``get_item`` takes.
 
     :returns: A list Requests if debug else a list of Responses.
@@ -402,6 +406,7 @@ def download(
         return_responses=return_responses,
         no_change_timestamp=no_change_timestamp,
         timeout=timeout,
+        count_views=count_views,
     )
     return r
 

--- a/internetarchive/cli/ia_download.py
+++ b/internetarchive/cli/ia_download.py
@@ -128,8 +128,13 @@ def setup(subparsers):
                         nargs=1,
                         action=QueryStringAction,
                         metavar="KEY:VALUE",
-                        help="Parameters to send with your download request (e.g. `cnt=0`). "
+                        help="Parameters to send with your download request. "
                              "Can be specified multiple times.")
+    parser.add_argument("--count-views",
+                        action="store_true",
+                        help="Count this download toward archive.org view "
+                             "counts. By default `ia download` opts out via "
+                             "`cnt=0`; this flag omits that parameter.")
     parser.add_argument("-a", "--download-history",
                         action="store_true",
                         help="Also download files from the history directory")
@@ -258,6 +263,7 @@ def main(args: argparse.Namespace, parser: argparse.ArgumentParser) -> None:
             exclude_source=args.exclude_source,
             stdout=args.stdout,
             timeout=args.timeout,
+            count_views=args.count_views,
         )
         if _errors:
             errors.append(_errors)

--- a/internetarchive/files.py
+++ b/internetarchive/files.py
@@ -170,6 +170,7 @@ class File(BaseFile):
         ors=None,
         timeout=None,
         headers=None,
+        count_views=False,
     ):
         """Download the file into the current working directory.
 
@@ -195,8 +196,15 @@ class File(BaseFile):
                        downloading to file.
         :param ors: Append a newline or $ORS to the end of file.
                     This is mainly intended to be used internally with `stdout`.
-        :param params: URL parameters to send with download request
-                       (e.g. ``cnt=0``).
+        :param params: URL parameters to send with download request.
+                       By default the library injects ``cnt=0`` so downloads do
+                       not count toward archive.org view counts; pass
+                       ``count_views=True`` to omit it. An explicit ``cnt`` key
+                       in ``params`` always wins.
+        :param count_views: If True, omit the default ``cnt=0`` parameter so
+                            the download counts toward archive.org view counts.
+                            Has no effect if ``params`` already contains a
+                            ``cnt`` key.
 
         :returns: ``True`` if file was successfully downloaded.
         """
@@ -208,7 +216,9 @@ class File(BaseFile):
         ignore_errors = ignore_errors or False
         return_responses = return_responses or False
         no_change_timestamp = no_change_timestamp or False
-        params = params or None
+        params = dict(params) if params else {}
+        if not count_views:
+            params.setdefault('cnt', '0')
         timeout = 12 if not timeout else timeout
         headers = headers or {}
         retries_sleep = 3  # TODO: exponential sleep

--- a/internetarchive/item.py
+++ b/internetarchive/item.py
@@ -735,7 +735,8 @@ class Item(BaseItem):
                  exclude_source: str | list[str] | None = None,
                  stdout: bool = False,
                  params: Mapping | None = None,
-                 timeout: float | tuple[int, float] | None = None
+                 timeout: float | tuple[int, float] | None = None,
+                 count_views: bool = False,
                  ) -> list[Request | Response]:
         """Download files from an item.
 
@@ -797,8 +798,14 @@ class Item(BaseItem):
         :param exclude_source: Filter files based on their source value in files.xml
                                (i.e. `original`, `derivative`, `metadata`).
 
-        :param params: URL parameters to send with
-                       download request (e.g. `cnt=0`).
+        :param params: URL parameters to send with the download request.
+                       By default the library injects ``cnt=0`` so downloads do
+                       not count toward archive.org view counts; pass
+                       ``count_views=True`` to omit it. An explicit ``cnt`` key
+                       in ``params`` always wins.
+
+        :param count_views: If True, omit the default ``cnt=0`` parameter so
+                            downloads count toward archive.org view counts.
 
         :param ignore_history_dir: Do not download any files from the history
                                    dir. This param defaults to ``False``.
@@ -895,7 +902,8 @@ class Item(BaseItem):
             try:
                 r = f.download(path, verbose, ignore_existing, checksum, checksum_archive,
                                destdir, retries, ignore_errors, fileobj, return_responses,
-                               no_change_timestamp, params, None, stdout, ors, timeout)
+                               no_change_timestamp, params, None, stdout, ors, timeout,
+                               count_views=count_views)
             except exceptions.DirectoryTraversalError as exc:  # type: ignore
                 # Record error and continue; do not abort entire download batch.
                 msg = f'error: {exc}'

--- a/tests/cli/test_ia_download.py
+++ b/tests/cli/test_ia_download.py
@@ -1,8 +1,10 @@
 import os
+import re
 import sys
 import time
 
 import pytest
+import responses
 
 from internetarchive import get_item
 from internetarchive.utils import json
@@ -224,3 +226,23 @@ def test_download_history_flag(capsys):
         item.download(dry_run=True, ignore_history_dir=False)
         stdout_with = capsys.readouterr().out
         assert 'history/files/old_file.txt' in stdout_with
+
+
+def test_count_views_flag(tmpdir_ch):
+    download_url_re = re.compile(r'https?://archive.org/download/.*')
+    with IaRequestsMock(assert_all_requests_are_fired=False) as rsps:
+        rsps.add_metadata_mock('nasa')
+        rsps.add(responses.GET, download_url_re, body='test content')
+        ia_call(['ia', '--insecure', 'download', '--no-directories',
+                 '--count-views', 'nasa', 'nasa_meta.xml'])
+        assert 'cnt=' not in rsps.calls[-1].request.url
+
+
+def test_default_sends_cnt_zero(tmpdir_ch):
+    download_url_re = re.compile(r'https?://archive.org/download/.*')
+    with IaRequestsMock(assert_all_requests_are_fired=False) as rsps:
+        rsps.add_metadata_mock('nasa')
+        rsps.add(responses.GET, download_url_re, body='test content')
+        ia_call(['ia', '--insecure', 'download', '--no-directories',
+                 'nasa', 'nasa_meta.xml'])
+        assert 'cnt=0' in rsps.calls[-1].request.url

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -76,3 +76,15 @@ def test_file_download_user_params_override_default_cnt(tmpdir, nasa_item):
         url = rsps.calls[-1].request.url
         assert 'cnt=x' in url
         assert 'cnt=0' not in url
+
+
+def test_item_download_count_views_propagates(tmpdir, nasa_item):
+    tmpdir.chdir()
+    with IaRequestsMock(assert_all_requests_are_fired=False) as rsps:
+        rsps.add(responses.GET, DOWNLOAD_URL_RE,
+                 body='test content',
+                 adding_headers=EXPECTED_LAST_MOD_HEADER)
+        nasa_item.download(files=['nasa_meta.xml'],
+                           destdir=str(tmpdir),
+                           count_views=True)
+        assert 'cnt=' not in rsps.calls[-1].request.url

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -41,3 +41,38 @@ def test_file_download_prevents_directory_traversal(tmpdir, nasa_item):
         malicious_path = os.path.join('..', 'nasa_meta.xml')
         with pytest.raises(DirectoryTraversalError, match=r"outside.*directory"):
             file_obj.download(file_path=malicious_path, destdir=str(tmpdir))
+
+
+def test_file_download_sends_cnt_zero_by_default(tmpdir, nasa_item):
+    tmpdir.chdir()
+    with IaRequestsMock(assert_all_requests_are_fired=False) as rsps:
+        rsps.add(responses.GET, DOWNLOAD_URL_RE,
+                 body='test content',
+                 adding_headers=EXPECTED_LAST_MOD_HEADER)
+        file_obj = nasa_item.get_file('nasa_meta.xml')
+        file_obj.download(destdir=str(tmpdir))
+        assert 'cnt=0' in rsps.calls[-1].request.url
+
+
+def test_file_download_count_views_true_omits_cnt(tmpdir, nasa_item):
+    tmpdir.chdir()
+    with IaRequestsMock(assert_all_requests_are_fired=False) as rsps:
+        rsps.add(responses.GET, DOWNLOAD_URL_RE,
+                 body='test content',
+                 adding_headers=EXPECTED_LAST_MOD_HEADER)
+        file_obj = nasa_item.get_file('nasa_meta.xml')
+        file_obj.download(destdir=str(tmpdir), count_views=True)
+        assert 'cnt=' not in rsps.calls[-1].request.url
+
+
+def test_file_download_user_params_override_default_cnt(tmpdir, nasa_item):
+    tmpdir.chdir()
+    with IaRequestsMock(assert_all_requests_are_fired=False) as rsps:
+        rsps.add(responses.GET, DOWNLOAD_URL_RE,
+                 body='test content',
+                 adding_headers=EXPECTED_LAST_MOD_HEADER)
+        file_obj = nasa_item.get_file('nasa_meta.xml')
+        file_obj.download(destdir=str(tmpdir), params={'cnt': 'x'})
+        url = rsps.calls[-1].request.url
+        assert 'cnt=x' in url
+        assert 'cnt=0' not in url


### PR DESCRIPTION
## Summary

- Make `ia download` and `File.download()` send `cnt=0` by default so
  downloads issued by this library no longer count toward archive.org
  view counts.
- Injected at the lowest level (`File.download()`) so the default
  propagates through the CLI, `Item.download()`, and the public
  `ia.download()` API — single source of truth.
- Opt back into counting via `--count-views` (CLI) or
  `count_views=True` (library). Both paths omit the `cnt` parameter
  entirely — the server only counts when `cnt` is absent, so passing
  `cnt=1` does not work. An explicit `-p cnt=<value>` still wins via
  `dict.setdefault` as an escape hatch.

## Test plan

- [x] New unit tests in `tests/test_files.py`:
  - `test_file_download_sends_cnt_zero_by_default` — `cnt=0` present
    in the recorded request URL.
  - `test_file_download_count_views_true_omits_cnt` — `count_views=True`
    causes `cnt` to be absent from the URL.
  - `test_file_download_user_params_override_default_cnt` — explicit
    `params={'cnt': 'x'}` overrides the default.
- [x] `ruff check` clean on modified files.
- [x] Full `pytest` suite: 259 passed, 37 skipped.
- [x] `ia download --help` shows the new `--count-views` flag.
- [ ] Manual sanity: `ia download <small-item> <file>` and confirm via
      HTTP debug logging that the GET URL ends with `?cnt=0`.
- [ ] Manual opt-back-in sanity: `ia download <id> <file> --count-views`
      and confirm no `cnt` parameter on the request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)