### PR TITLE
Add `ia download --range` for partial (byte-range) downloads

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,13 +8,18 @@ Release History
 
 **Features and Improvements**
 
-- Added ``ia download --range START-END`` for partial (byte-range) downloads.
-  This sends an HTTP ``Range`` header and is most useful with ``--stdout`` for
-  fetching part of a file (including from private items, using configured
-  credentials). ``Item.download()``, ``File.download()``, and the top-level
-  ``internetarchive.download()`` gained a ``headers`` argument; passing a
-  ``Range`` header is treated as an intentional partial fetch and disables
-  resume and full-file checksum validation.
+- Added ``ia download --range`` for partial (byte-range) downloads. It requires
+  ``--stdout`` and is repeatable, taking ``[FILE:]START-END`` values: a bare
+  range binds to the named file (vary the range or the file, not both at once),
+  or ``FILE:START-END`` binds each range to its own file. Segments are streamed
+  back-to-back with no separator, so e.g. WARC records selected via a CDX
+  index's compressed offset/length can be piped straight to ``zcat``. Useful
+  for partial fetches of private items (configured credentials are used).
+  ``Item.download()``, ``File.download()``, and the top-level
+  ``internetarchive.download()`` gained a ``headers`` argument, and
+  ``Item.download()`` a ``range_jobs`` argument; passing a ``Range`` header is
+  treated as an intentional partial fetch and disables resume and full-file
+  checksum validation.
 
 **Bugfixes**
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -11,17 +11,28 @@ Release History
 - Added ``ia download --range`` for partial (byte-range) downloads. It requires
   ``--stdout`` and is repeatable, taking ``[FILE:]START-END`` values: a bare
   range binds to the named file (vary the range or the file, not both at once),
-  or ``FILE:START-END`` binds each range to its own file. Segments are streamed
-  back-to-back with no separator, so e.g. WARC records selected via a CDX
-  index's compressed offset/length can be piped straight to ``zcat``. Useful
-  for partial fetches of private items (configured credentials are used).
-  ``Item.download()``, ``File.download()``, and the top-level
-  ``internetarchive.download()`` gained a ``headers`` argument, and
+  or ``FILE:START-END`` binds each range to its own file. Ranges may be given as
+  ``START-END``, open-ended ``START-``, suffix ``-N`` (the last ``N`` bytes), or
+  ``bytes=...``, and a single value may carry several comma-separated ranges
+  (``0-9,50-99``), fetched in order. Segments are streamed back-to-back with no separator, so e.g.
+  WARC records selected via a CDX index's compressed offset/length can be piped
+  straight to ``zcat``. Useful for partial fetches of private items (configured
+  credentials are used). ``Item.download()``, ``File.download()``, and the
+  top-level ``internetarchive.download()`` gained a ``headers`` argument, and
   ``Item.download()`` a ``range_jobs`` argument; passing a ``Range`` header is
   treated as an intentional partial fetch and disables resume and full-file
-  checksum validation.
+  checksum validation. An unsatisfiable range (HTTP ``416``) fails fast with a
+  clear message instead of being retried; a range covering the whole file
+  returns the full contents (HTTP ``200``).
 
 **Bugfixes**
+
+- Fixed ``File.download(stdout=True)`` consulting the local filesystem: a
+  same-named local file could cause the stream to be skipped (length/date or
+  checksum match) or trigger the auto-resume code path, which seeks the output
+  and fails on a pipe. A stdout download now ignores any on-disk file.
+- Fixed auto-resume discarding caller-supplied headers; the internal ``Range``
+  header is now merged into the provided ``headers`` rather than replacing them.
 
 - Fixed ``ia tasks --parameter`` crashing when combined with
   ``--get-task-log``. Parameters such as ``lines`` are now merged into the

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,16 @@ Release History
 5.10.0 (unreleased)
 +++++++++++++++++++
 
+**Features and Improvements**
+
+- Added ``ia download --range START-END`` for partial (byte-range) downloads.
+  This sends an HTTP ``Range`` header and is most useful with ``--stdout`` for
+  fetching part of a file (including from private items, using configured
+  credentials). ``Item.download()``, ``File.download()``, and the top-level
+  ``internetarchive.download()`` gained a ``headers`` argument; passing a
+  ``Range`` header is treated as an intentional partial fetch and disables
+  resume and full-file checksum validation.
+
 **Bugfixes**
 
 - Fixed ``ia tasks --parameter`` crashing when combined with

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -33,6 +33,21 @@ Release History
   and fails on a pipe. A stdout download now ignores any on-disk file.
 - Fixed auto-resume discarding caller-supplied headers; the internal ``Range``
   header is now merged into the provided ``headers`` rather than replacing them.
+- Fixed a retried ``stdout`` download falling back to writing a local disk file
+  instead of the pipe (leaving the pipe empty). A ``stdout`` download now always
+  writes to ``stdout``, even across retries.
+- Fixed auto-resume corrupting a file when a resumed transfer was itself retried:
+  the internal ``Range`` header was not recomputed for the retry, so it no longer
+  matched the (grown) local file and the seek offset, re-fetching already-written
+  bytes. The resume ``Range`` is now recomputed from the current file size on
+  every attempt.
+- Fixed the explicit-range check being case-sensitive, so a caller-supplied
+  lowercase ``range`` header was silently clobbered by an auto-resume ``Range``.
+  The check is now case-insensitive.
+- Fixed ranged ``--range`` segment failures being silently swallowed: a failed
+  segment now surfaces as a download error (nonzero exit), and caller-supplied
+  ``headers`` are forwarded to every ranged request (merged with the per-segment
+  ``Range``).
 
 - Fixed ``ia tasks --parameter`` crashing when combined with
   ``--get-task-log``. Parameters such as ``lines`` are now merged into the

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -314,7 +314,7 @@ See ``ia download --help`` for more details.
 Downloading byte ranges
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-You can download only part of a file with ``--range``, which sends an HTTP ``Range`` header. It **requires** ``--stdout`` (so you can pipe or redirect the bytes), uses your configured credentials (so private items work), and can be specified multiple times. A range may be given as ``START-END``, an open-ended ``START-`` (e.g. ``1024-``), or ``bytes=START-END``.
+You can download only part of a file with ``--range``, which sends an HTTP ``Range`` header. It **requires** ``--stdout`` (so you can pipe or redirect the bytes), uses your configured credentials (so private items work), and can be specified multiple times. A range may be given as ``START-END``, an open-ended ``START-`` (e.g. ``1024-``), a suffix ``-N`` (the last ``N`` bytes, e.g. ``-1024``), or ``bytes=START-END``.
 
 A bare range applies to the file named on the command line:
 
@@ -331,6 +331,12 @@ With bare ranges you may vary *either* the range *or* the file, but not both at 
     # the same range from several files
     $ ia download ITEM a.bin b.bin --stdout --range 0-1023
 
+Multiple ranges for one file may also be given as a single comma-separated value (the HTTP multi-range syntax); they are fetched in order, exactly as if you had repeated ``--range``:
+
+.. code:: console
+
+    $ ia download ITEM file.bin --stdout --range 0-1023,4096-8191
+
 To pull ranges from *different* files, bind each range to its file with ``FILE:START-END``:
 
 .. code:: console
@@ -344,7 +350,7 @@ Segments are written back-to-back with **no separator** between them (unlike a n
     # CDX fields: ... S(length) V(offset) g(filename); range is V-(V+S-1)
     $ ia download ITEM crawl.warc.gz --stdout --range 270034594-270035614 | zcat
 
-Because a ranged download is an intentional partial fetch, resume and full-file checksum validation are disabled for the request.
+Because a ranged download is an intentional partial fetch, resume and full-file checksum validation are disabled for the request. A range that lies entirely beyond the end of the file is rejected by the server (HTTP ``416``) and fails immediately with a clear error; a range that covers the whole file simply returns the full contents.
 
 
 Downloading On-The-Fly Files

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -311,6 +311,14 @@ Download from an itemlist:
 
 See ``ia download --help`` for more details.
 
+You can download only a portion of a file with ``--range``. This sends an HTTP ``Range`` header and is most useful together with ``--stdout`` for inspecting part of a (possibly private) file without fetching the whole thing. Your configured credentials are used, so private items are supported:
+
+.. code:: console
+
+    $ ia download TripDown1905 TripDown1905.ogv --range 0-1023 --stdout > head.bin
+
+The range may be given as ``START-END`` or as an open-ended ``START-`` (e.g. ``1024-``). Because a ranged download is an intentional partial fetch, resume and full-file checksum validation are disabled for that request.
+
 
 Downloading On-The-Fly Files
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -311,13 +311,40 @@ Download from an itemlist:
 
 See ``ia download --help`` for more details.
 
-You can download only a portion of a file with ``--range``. This sends an HTTP ``Range`` header and is most useful together with ``--stdout`` for inspecting part of a (possibly private) file without fetching the whole thing. Your configured credentials are used, so private items are supported:
+Downloading byte ranges
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+You can download only part of a file with ``--range``, which sends an HTTP ``Range`` header. It **requires** ``--stdout`` (so you can pipe or redirect the bytes), uses your configured credentials (so private items work), and can be specified multiple times. A range may be given as ``START-END``, an open-ended ``START-`` (e.g. ``1024-``), or ``bytes=START-END``.
+
+A bare range applies to the file named on the command line:
 
 .. code:: console
 
-    $ ia download TripDown1905 TripDown1905.ogv --range 0-1023 --stdout > head.bin
+    $ ia download TripDown1905 TripDown1905.ogv --stdout --range 0-1023 > head.bin
 
-The range may be given as ``START-END`` or as an open-ended ``START-`` (e.g. ``1024-``). Because a ranged download is an intentional partial fetch, resume and full-file checksum validation are disabled for that request.
+With bare ranges you may vary *either* the range *or* the file, but not both at once — give multiple ranges for one file, or one range for several files:
+
+.. code:: console
+
+    # multiple ranges from one file
+    $ ia download ITEM file.bin --stdout --range 0-1023 --range 4096-8191
+    # the same range from several files
+    $ ia download ITEM a.bin b.bin --stdout --range 0-1023
+
+To pull ranges from *different* files, bind each range to its file with ``FILE:START-END``:
+
+.. code:: console
+
+    $ ia download ITEM --stdout --range a.warc.gz:0-9 --range b.warc.gz:50-99
+
+Segments are written back-to-back with **no separator** between them (unlike a normal multi-file ``--stdout``, which inserts the ORS). This means concatenated gzip members stay byte-adjacent, so you can extract WARC records using the compressed offset/length from a CDX index and pipe straight to ``zcat``:
+
+.. code:: console
+
+    # CDX fields: ... S(length) V(offset) g(filename); range is V-(V+S-1)
+    $ ia download ITEM crawl.warc.gz --stdout --range 270034594-270035614 | zcat
+
+Because a ranged download is an intentional partial fetch, resume and full-file checksum validation are disabled for the request.
 
 
 Downloading On-The-Fly Files

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -350,7 +350,7 @@ Segments are written back-to-back with **no separator** between them (unlike a n
     # CDX fields: ... S(length) V(offset) g(filename); range is V-(V+S-1)
     $ ia download ITEM crawl.warc.gz --stdout --range 270034594-270035614 | zcat
 
-Because a ranged download is an intentional partial fetch, resume and full-file checksum validation are disabled for the request. A range that lies entirely beyond the end of the file is rejected by the server (HTTP ``416``) and fails immediately with a clear error; a range that covers the whole file simply returns the full contents.
+Because a ranged download is an intentional partial fetch, resume and full-file checksum validation are disabled for the request. A range that lies entirely beyond the end of the file is rejected by the server (HTTP ``416``) and fails immediately with a clear error; a range that covers the whole file simply returns the full contents. If any segment fails, ``ia download`` exits non-zero, so a downstream pipe consumer can tell the output is incomplete.
 
 
 Downloading On-The-Fly Files

--- a/internetarchive/__version__.py
+++ b/internetarchive/__version__.py
@@ -1,1 +1,1 @@
-__version__ = '5.10.0.dev2'
+__version__ = '5.10.0.dev3'

--- a/internetarchive/api.py
+++ b/internetarchive/api.py
@@ -333,6 +333,7 @@ def download(
     no_change_timestamp: bool = False,
     timeout: float | tuple[int, float] | None = None,
     count_views: bool = False,
+    headers: Mapping | None = None,
     **get_item_kwargs,
 ) -> list[requests.Request | requests.Response]:
     r"""Download files from an item.
@@ -383,6 +384,12 @@ def download(
     :param count_views: If True, omit the default ``cnt=0`` parameter so
                         downloads count toward archive.org view counts.
 
+    :param headers: Extra HTTP headers to send with each download request.
+                    Supplying a ``Range`` header (e.g.
+                    ``{'Range': 'bytes=0-1023'}``) performs an intentional
+                    partial fetch, skipping resume and full-file checksum
+                    validation.
+
     :param \*\*kwargs: Optional arguments that ``get_item`` takes.
 
     :returns: A list Requests if debug else a list of Responses.
@@ -407,6 +414,7 @@ def download(
         no_change_timestamp=no_change_timestamp,
         timeout=timeout,
         count_views=count_views,
+        headers=headers,
     )
     return r
 

--- a/internetarchive/cli/ia_download.py
+++ b/internetarchive/cli/ia_download.py
@@ -257,21 +257,17 @@ def build_range_jobs(
            "FILE:START-END[,...]")
     parsed: list[tuple[str | None, str]] = []
     for raw in args.ranges:
-        # A bare value parses (in full) as one or more comma-separated ranges.
-        try:
-            for rng in parse_byte_ranges(raw):
-                parsed.append((None, rng))
-            continue
-        except ValueError:
-            pass
-        # Otherwise it must be FILE:RANGES (split on the last colon so file
-        # names containing a colon still work).
+        # A bare range never contains a colon (only digits, '-', ',', and an
+        # optional leading 'bytes='), so a ':' unambiguously marks the FILE:RANGES
+        # form. Split on the last colon so filenames containing a colon still work.
         file_part, sep, range_part = raw.rpartition(":")
-        if not sep or not file_part:
-            parser.error(f"could not parse --range {raw!r}: {err}")
+        if sep and file_part:
+            target, spec = file_part, range_part
+        else:
+            target, spec = None, raw
         try:
-            for rng in parse_byte_ranges(range_part):
-                parsed.append((file_part, rng))
+            for rng in parse_byte_ranges(spec):
+                parsed.append((target, rng))
         except ValueError:
             parser.error(f"could not parse --range {raw!r}: {err}")
 

--- a/internetarchive/cli/ia_download.py
+++ b/internetarchive/cli/ia_download.py
@@ -127,9 +127,12 @@ def setup(subparsers):
                         metavar="[FILE:]START-END",
                         help="Download only the given byte range(s). Requires "
                              "--stdout and can be specified multiple times. A bare "
-                             "range (e.g. `0-1023`, `bytes=0-1023`, or open-ended "
-                             "`1024-`) applies to the named file; use one file with "
-                             "multiple ranges, or one range with multiple files. To "
+                             "range (e.g. `0-1023`, `bytes=0-1023`, open-ended "
+                             "`1024-`, or suffix `-1024` for the last 1024 bytes) "
+                             "applies to the named file; use one file with "
+                             "multiple ranges, or one range with multiple files. "
+                             "Comma-separated ranges (e.g. `0-1023,4096-8191`) are "
+                             "fetched in order, equivalent to repeating --range. To "
                              "pull ranges from different files, bind each explicitly "
                              "as FILE:START-END (e.g. `--range a.warc.gz:0-9 --range "
                              "b.warc.gz:50-99`). Segments are written back-to-back "
@@ -177,8 +180,9 @@ def setup(subparsers):
 def normalize_byte_range(value: str) -> str:
     """Normalize a user-supplied ``--range`` value into an HTTP Range header value.
 
-    Accepts ``START-END``, ``START-`` (open-ended), or a value already prefixed
-    with ``bytes=``. Returns a string of the form ``bytes=START-END``.
+    Accepts ``START-END``, open-ended ``START-``, suffix ``-N`` (the last ``N``
+    bytes), or a value already prefixed with ``bytes=``. Returns a string of the
+    form ``bytes=...``.
 
     :param value: The raw ``--range`` argument.
     :returns: A normalized ``bytes=...`` Range header value.
@@ -187,12 +191,34 @@ def normalize_byte_range(value: str) -> str:
     spec = value.strip()
     if spec.lower().startswith("bytes="):
         spec = spec[len("bytes="):]
-    if not re.fullmatch(r"\d+-\d*", spec):
+    if not re.fullmatch(r"\d+-\d*|-\d+", spec):
         raise ValueError(f"invalid byte range: {value!r}")
     start, _, end = spec.partition("-")
-    if end and int(end) < int(start):
+    if start and end and int(end) < int(start):
         raise ValueError(f"range end is before range start: {value!r}")
     return f"bytes={spec}"
+
+
+def parse_byte_ranges(value: str) -> list[str]:
+    """Parse a (possibly comma-separated) ``--range`` value into Range headers.
+
+    Accepts the HTTP multi-range syntax: one or more comma-separated byte ranges
+    with an optional single leading ``bytes=`` (e.g. ``50-99,123-180`` or
+    ``bytes=0-9,-100``). Each range is normalized independently and returned as
+    its own ``bytes=...`` value -- one per upstream request, since we expand a
+    comma list client-side rather than sending a single multi-range request.
+
+    :param value: The raw ``--range`` argument.
+    :returns: One normalized ``bytes=...`` value per comma-separated range.
+    :raises ValueError: If the value is empty or any segment is not a valid range.
+    """
+    spec = value.strip()
+    if spec.lower().startswith("bytes="):
+        spec = spec[len("bytes="):]
+    parts = spec.split(",")
+    if any(p.strip() == "" for p in parts):
+        raise ValueError(f"invalid byte range: {value!r}")
+    return [normalize_byte_range(p) for p in parts]
 
 
 def positional_files(args: argparse.Namespace) -> list[str]:
@@ -217,33 +243,37 @@ def build_range_jobs(
     """Resolve repeatable ``--range`` values into an ordered job list.
 
     Each ``--range`` value is either a bare ``[bytes=]START-END`` (which binds to
-    the explicitly-named file) or a file-bound ``FILE:START-END``. Returns an
-    ordered list of ``(filename, "bytes=...")`` jobs. Any rule violation is
-    reported via ``parser.error`` (which exits with status 2).
+    the explicitly-named file) or a file-bound ``FILE:START-END``. A value may
+    carry several comma-separated ranges (HTTP multi-range syntax, e.g.
+    ``0-9,50-99``), which expand to one job each, in order. Returns an ordered
+    list of ``(filename, "bytes=...")`` jobs. Any rule violation is reported via
+    ``parser.error`` (which exits with status 2).
 
     :param args: Parsed CLI arguments (``args.ranges`` holds the raw values).
     :param parser: The argument parser, used to emit errors.
     :returns: Ordered ``(filename, range_header_value)`` jobs.
     """
+    err = ("expected [bytes=]START-END[,START-END...] or "
+           "FILE:START-END[,...]")
     parsed: list[tuple[str | None, str]] = []
     for raw in args.ranges:
-        # A bare range is anything that parses as a range on its own.
+        # A bare value parses (in full) as one or more comma-separated ranges.
         try:
-            parsed.append((None, normalize_byte_range(raw)))
+            for rng in parse_byte_ranges(raw):
+                parsed.append((None, rng))
             continue
         except ValueError:
             pass
-        # Otherwise it must be FILE:START-END (split on the last colon so file
+        # Otherwise it must be FILE:RANGES (split on the last colon so file
         # names containing a colon still work).
         file_part, sep, range_part = raw.rpartition(":")
         if not sep or not file_part:
-            parser.error(f"could not parse --range {raw!r}: "
-                         "expected START-END or FILE:START-END")
+            parser.error(f"could not parse --range {raw!r}: {err}")
         try:
-            parsed.append((file_part, normalize_byte_range(range_part)))
+            for rng in parse_byte_ranges(range_part):
+                parsed.append((file_part, rng))
         except ValueError:
-            parser.error(f"could not parse --range {raw!r}: "
-                         "expected START-END or FILE:START-END")
+            parser.error(f"could not parse --range {raw!r}: {err}")
 
     has_bare = any(f is None for f, _ in parsed)
     has_bound = any(f is not None for f, _ in parsed)
@@ -301,6 +331,9 @@ def validate_args(args: argparse.Namespace, parser: argparse.ArgumentParser) -> 
     if args.ranges:
         if not args.stdout:
             parser.error("--range requires --stdout")
+        if args.identifier == "-":
+            parser.error("--range cannot be combined with reading identifiers "
+                         "from stdin")
         args.range_jobs = build_range_jobs(args, parser)
     else:
         args.range_jobs = None

--- a/internetarchive/cli/ia_download.py
+++ b/internetarchive/cli/ia_download.py
@@ -22,6 +22,7 @@ ia_download.py
 from __future__ import annotations
 
 import argparse
+import re
 import sys
 from typing import TextIO
 
@@ -120,6 +121,14 @@ def setup(subparsers):
     parser.add_argument("-s", "--stdout",
                         action="store_true",
                         help="Write file contents to stdout")
+    parser.add_argument("--range",
+                        dest="byte_range",
+                        metavar="START-END",
+                        help="Download only the given byte range, e.g. `0-1023` "
+                             "(or `bytes=0-1023`). Most useful with --stdout for "
+                             "partial fetches of (private) item files. Disables "
+                             "resume and full-file checksum validation. Open-ended "
+                             "ranges such as `1024-` are allowed.")
     parser.add_argument("--no-change-timestamp",
                         action="store_true",
                         help=("Don't change the timestamp of downloaded files to reflect "
@@ -158,6 +167,27 @@ def setup(subparsers):
     parser.set_defaults(func=lambda args: main(args, parser))
 
 
+def normalize_byte_range(value: str) -> str:
+    """Normalize a user-supplied ``--range`` value into an HTTP Range header value.
+
+    Accepts ``START-END``, ``START-`` (open-ended), or a value already prefixed
+    with ``bytes=``. Returns a string of the form ``bytes=START-END``.
+
+    :param value: The raw ``--range`` argument.
+    :returns: A normalized ``bytes=...`` Range header value.
+    :raises ValueError: If the range is not a valid single byte range.
+    """
+    spec = value.strip()
+    if spec.lower().startswith("bytes="):
+        spec = spec[len("bytes="):]
+    if not re.fullmatch(r"\d+-\d*", spec):
+        raise ValueError(f"invalid byte range: {value!r}")
+    start, _, end = spec.partition("-")
+    if end and int(end) < int(start):
+        raise ValueError(f"range end is before range start: {value!r}")
+    return f"bytes={spec}"
+
+
 def validate_args(args: argparse.Namespace, parser: argparse.ArgumentParser) -> None:
     if args.itemlist and args.search:
         parser.error("--itemlist and --search cannot be used together")
@@ -171,6 +201,12 @@ def validate_args(args: argparse.Namespace, parser: argparse.ArgumentParser) -> 
         if not args.identifier:
             parser.error("Identifier is required when not using --itemlist/--search")
 
+    if args.byte_range:
+        try:
+            args.byte_range = normalize_byte_range(args.byte_range)
+        except ValueError as exc:
+            parser.error(str(exc))
+
 
 def main(args: argparse.Namespace, parser: argparse.ArgumentParser) -> None:
     """
@@ -181,6 +217,9 @@ def main(args: argparse.Namespace, parser: argparse.ArgumentParser) -> None:
 
     ids: list[File | str] | Search | TextIO
     validate_args(args, parser)
+
+    # Built after validate_args so byte_range is normalized to a `bytes=...` value.
+    headers = {"Range": args.byte_range} if args.byte_range else None
 
     if args.itemlist:
         ids = [x.strip() for x in args.itemlist if x.strip()]
@@ -264,6 +303,7 @@ def main(args: argparse.Namespace, parser: argparse.ArgumentParser) -> None:
             stdout=args.stdout,
             timeout=args.timeout,
             count_views=args.count_views,
+            headers=headers,
         )
         if _errors:
             errors.append(_errors)

--- a/internetarchive/cli/ia_download.py
+++ b/internetarchive/cli/ia_download.py
@@ -122,13 +122,20 @@ def setup(subparsers):
                         action="store_true",
                         help="Write file contents to stdout")
     parser.add_argument("--range",
-                        dest="byte_range",
-                        metavar="START-END",
-                        help="Download only the given byte range, e.g. `0-1023` "
-                             "(or `bytes=0-1023`). Most useful with --stdout for "
-                             "partial fetches of (private) item files. Disables "
-                             "resume and full-file checksum validation. Open-ended "
-                             "ranges such as `1024-` are allowed.")
+                        dest="ranges",
+                        action="append",
+                        metavar="[FILE:]START-END",
+                        help="Download only the given byte range(s). Requires "
+                             "--stdout and can be specified multiple times. A bare "
+                             "range (e.g. `0-1023`, `bytes=0-1023`, or open-ended "
+                             "`1024-`) applies to the named file; use one file with "
+                             "multiple ranges, or one range with multiple files. To "
+                             "pull ranges from different files, bind each explicitly "
+                             "as FILE:START-END (e.g. `--range a.warc.gz:0-9 --range "
+                             "b.warc.gz:50-99`). Segments are written back-to-back "
+                             "with no separator, so e.g. selected .warc.gz records "
+                             "can be piped straight to zcat. Disables resume and "
+                             "full-file checksum validation for partial fetches.")
     parser.add_argument("--no-change-timestamp",
                         action="store_true",
                         help=("Don't change the timestamp of downloaded files to reflect "
@@ -188,6 +195,96 @@ def normalize_byte_range(value: str) -> str:
     return f"bytes={spec}"
 
 
+def positional_files(args: argparse.Namespace) -> list[str]:
+    """Return the files named explicitly on the command line.
+
+    Handles both the ``<id> FILE [FILE ...]`` and the ``<id>/path`` forms.
+
+    :param args: Parsed CLI arguments.
+    :returns: The list of explicitly-named files (empty if none).
+    """
+    if args.identifier and args.identifier != "-":
+        if "/" in args.identifier:
+            return ["/".join(args.identifier.split("/")[1:])]
+        return list(args.file)
+    return []
+
+
+def build_range_jobs(
+    args: argparse.Namespace,
+    parser: argparse.ArgumentParser,
+) -> list[tuple[str, str]]:
+    """Resolve repeatable ``--range`` values into an ordered job list.
+
+    Each ``--range`` value is either a bare ``[bytes=]START-END`` (which binds to
+    the explicitly-named file) or a file-bound ``FILE:START-END``. Returns an
+    ordered list of ``(filename, "bytes=...")`` jobs. Any rule violation is
+    reported via ``parser.error`` (which exits with status 2).
+
+    :param args: Parsed CLI arguments (``args.ranges`` holds the raw values).
+    :param parser: The argument parser, used to emit errors.
+    :returns: Ordered ``(filename, range_header_value)`` jobs.
+    """
+    parsed: list[tuple[str | None, str]] = []
+    for raw in args.ranges:
+        # A bare range is anything that parses as a range on its own.
+        try:
+            parsed.append((None, normalize_byte_range(raw)))
+            continue
+        except ValueError:
+            pass
+        # Otherwise it must be FILE:START-END (split on the last colon so file
+        # names containing a colon still work).
+        file_part, sep, range_part = raw.rpartition(":")
+        if not sep or not file_part:
+            parser.error(f"could not parse --range {raw!r}: "
+                         "expected START-END or FILE:START-END")
+        try:
+            parsed.append((file_part, normalize_byte_range(range_part)))
+        except ValueError:
+            parser.error(f"could not parse --range {raw!r}: "
+                         "expected START-END or FILE:START-END")
+
+    has_bare = any(f is None for f, _ in parsed)
+    has_bound = any(f is not None for f, _ in parsed)
+    if has_bare and has_bound:
+        parser.error("--range: cannot mix bare ranges (START-END) and file-bound "
+                     "ranges (FILE:START-END) in the same command")
+
+    selectors = [name for name, val in (
+        ("--glob", args.glob),
+        ("--format", args.format),
+        ("--source", args.source),
+        ("--exclude-source", args.exclude_source),
+        ("--search", args.search),
+        ("--itemlist", args.itemlist),
+    ) if val]
+    if selectors:
+        parser.error(f"--range cannot be combined with {', '.join(selectors)}")
+
+    if has_bound:
+        if positional_files(args):
+            parser.error("--range FILE:START-END cannot be combined with positional "
+                         "file arguments; the files come from the --range values")
+        return [(str(f), b) for f, b in parsed]
+
+    # Bare form: bind ranges to the positional file(s).
+    files = positional_files(args)
+    if not files:
+        first = args.ranges[0]
+        parser.error(f"--range {first} needs a file: name one positionally "
+                     f"(ia download ID FILE --range {first}) or bind it "
+                     f"(--range FILE:{first})")
+    if len(files) > 1 and len(parsed) > 1:
+        parser.error(f"ambiguous --range: {len(parsed)} ranges and {len(files)} files "
+                     "given. With more than one file, bind each range to its file "
+                     "explicitly, e.g. `--range FILE1:0-9 --range FILE2:55-99`.")
+    if len(parsed) == 1:
+        rng = parsed[0][1]
+        return [(f, rng) for f in files]
+    return [(files[0], b) for _, b in parsed]
+
+
 def validate_args(args: argparse.Namespace, parser: argparse.ArgumentParser) -> None:
     if args.itemlist and args.search:
         parser.error("--itemlist and --search cannot be used together")
@@ -201,11 +298,12 @@ def validate_args(args: argparse.Namespace, parser: argparse.ArgumentParser) -> 
         if not args.identifier:
             parser.error("Identifier is required when not using --itemlist/--search")
 
-    if args.byte_range:
-        try:
-            args.byte_range = normalize_byte_range(args.byte_range)
-        except ValueError as exc:
-            parser.error(str(exc))
+    if args.ranges:
+        if not args.stdout:
+            parser.error("--range requires --stdout")
+        args.range_jobs = build_range_jobs(args, parser)
+    else:
+        args.range_jobs = None
 
 
 def main(args: argparse.Namespace, parser: argparse.ArgumentParser) -> None:
@@ -217,9 +315,6 @@ def main(args: argparse.Namespace, parser: argparse.ArgumentParser) -> None:
 
     ids: list[File | str] | Search | TextIO
     validate_args(args, parser)
-
-    # Built after validate_args so byte_range is normalized to a `bytes=...` value.
-    headers = {"Range": args.byte_range} if args.byte_range else None
 
     if args.itemlist:
         ids = [x.strip() for x in args.itemlist if x.strip()]
@@ -303,7 +398,7 @@ def main(args: argparse.Namespace, parser: argparse.ArgumentParser) -> None:
             stdout=args.stdout,
             timeout=args.timeout,
             count_views=args.count_views,
-            headers=headers,
+            range_jobs=args.range_jobs,
         )
         if _errors:
             errors.append(_errors)

--- a/internetarchive/files.py
+++ b/internetarchive/files.py
@@ -205,6 +205,12 @@ class File(BaseFile):
                             the download counts toward archive.org view counts.
                             Has no effect if ``params`` already contains a
                             ``cnt`` key.
+        :param headers: Extra HTTP headers to send with the download request.
+                        Supplying a ``Range`` header (e.g.
+                        ``{'Range': 'bytes=0-1023'}``) performs an intentional
+                        partial fetch: the automatic resume behaviour and
+                        full-file checksum validation are skipped, so the bytes
+                        returned by the server are written as-is.
 
         :returns: ``True`` if file was successfully downloaded.
         """
@@ -223,6 +229,7 @@ class File(BaseFile):
         headers = headers or {}
         retries_sleep = 3  # TODO: exponential sleep
         retrying = False  # for retry loop
+        resume = False  # True when auto-resuming a partial local download
 
         self.item.session.mount_http_adapter(max_retries=retries)
         file_path = file_path or self.name
@@ -317,8 +324,15 @@ class File(BaseFile):
                         and self.name != f'{self.identifier}_files.xml' \
                         and os.path.exists(file_path.encode('utf-8')):
                     st = os.stat(file_path.encode('utf-8'))
-                    if st.st_size != self.size and not (checksum or checksum_archive):
+                    # Only auto-resume when the caller has not supplied an explicit
+                    # Range header (e.g. via the ``--range`` CLI flag). An explicit
+                    # range is an intentional partial fetch and must not trigger the
+                    # resume seek/append or the full-file checksum validation below.
+                    if st.st_size != self.size \
+                            and not (checksum or checksum_archive) \
+                            and 'Range' not in headers:
                         headers = {"Range": f"bytes={st.st_size}-"}
+                        resume = True
 
                 response = self.item.session.get(
                     self.url,
@@ -368,13 +382,13 @@ class File(BaseFile):
                 if stdout:
                     fileobj = os.fdopen(sys.stdout.fileno(), 'wb', closefd=False)
                 if not fileobj or retrying:
-                    if 'Range' in headers:
+                    if resume:
                         fileobj = open(file_path.encode('utf-8'), 'rb+')
                     else:
                         fileobj = open(file_path.encode('utf-8'), 'wb')
 
                 with fileobj, progress_bar as bar:
-                    if 'Range' in headers:
+                    if resume:
                         fileobj.seek(st.st_size)
                     for chunk in response.iter_content(chunk_size=chunk_size):
                         if chunk:
@@ -384,7 +398,7 @@ class File(BaseFile):
                     if ors:
                         fileobj.write(os.environ.get("ORS", "\n").encode("utf-8"))
 
-                if 'Range' in headers:
+                if resume:
                     with open(file_path, 'rb') as fh:
                         local_checksum = utils.get_md5(fh)
                     try:

--- a/internetarchive/files.py
+++ b/internetarchive/files.py
@@ -230,6 +230,10 @@ class File(BaseFile):
         retries_sleep = 3  # TODO: exponential sleep
         retrying = False  # for retry loop
         resume = False  # True when auto-resuming a partial local download
+        # Whether the caller supplied an explicit Range header (case-insensitive).
+        # An explicit range is an intentional partial fetch and must never trigger
+        # auto-resume or full-file checksum validation.
+        explicit_range = any(k.lower() == 'range' for k in headers)
 
         self.item.session.mount_http_adapter(max_retries=retries)
         file_path = file_path or self.name
@@ -334,7 +338,11 @@ class File(BaseFile):
                     # and there is no local partial file to append to.)
                     if st.st_size != self.size \
                             and not (checksum or checksum_archive) \
-                            and 'Range' not in headers:
+                            and not explicit_range:
+                        # Recompute the resume Range from the current file size on
+                        # every attempt so it stays aligned with the seek offset
+                        # below; a stale Range left over from a prior attempt would
+                        # re-fetch already-written bytes and corrupt the file.
                         # Preserve any caller-supplied headers; only set Range.
                         headers = {**headers, "Range": f"bytes={st.st_size}-"}
                         resume = True
@@ -386,8 +394,10 @@ class File(BaseFile):
                 if not chunk_size:
                     chunk_size = 1048576
                 if stdout:
+                    # stdout is its own sink; never fall back to a local file,
+                    # even on a retry (which must keep writing to the pipe).
                     fileobj = os.fdopen(sys.stdout.fileno(), 'wb', closefd=False)
-                if not fileobj or retrying:
+                elif not fileobj or retrying:
                     if resume:
                         fileobj = open(file_path.encode('utf-8'), 'rb+')
                     else:

--- a/internetarchive/files.py
+++ b/internetarchive/files.py
@@ -274,8 +274,9 @@ class File(BaseFile):
             if verbose:
                 print(f' warning: long path may cause issues: {file_path}', file=sys.stderr)
 
-        # Check if we should skip...
-        if not return_responses and os.path.exists(file_path.encode('utf-8')):
+        # Check if we should skip... (never when streaming to stdout: the
+        # local filesystem is irrelevant to a stdout download).
+        if not return_responses and not stdout and os.path.exists(file_path.encode('utf-8')):
             if checksum_archive:
                 checksum_archive_filename = '_checksum_archive.txt'
                 if not os.path.exists(checksum_archive_filename):
@@ -320,6 +321,7 @@ class File(BaseFile):
                     os.makedirs(parent_dir, exist_ok=True)
 
                 if not return_responses \
+                        and not stdout \
                         and not ignore_existing \
                         and self.name != f'{self.identifier}_files.xml' \
                         and os.path.exists(file_path.encode('utf-8')):
@@ -328,10 +330,13 @@ class File(BaseFile):
                     # Range header (e.g. via the ``--range`` CLI flag). An explicit
                     # range is an intentional partial fetch and must not trigger the
                     # resume seek/append or the full-file checksum validation below.
+                    # (Resume is also skipped for stdout, since seeking a pipe fails
+                    # and there is no local partial file to append to.)
                     if st.st_size != self.size \
                             and not (checksum or checksum_archive) \
                             and 'Range' not in headers:
-                        headers = {"Range": f"bytes={st.st_size}-"}
+                        # Preserve any caller-supplied headers; only set Range.
+                        headers = {**headers, "Range": f"bytes={st.st_size}-"}
                         resume = True
 
                 response = self.item.session.get(
@@ -353,7 +358,8 @@ class File(BaseFile):
                 response.raise_for_status()
 
                 # Check if we should skip based on last modified time...
-                if not fileobj and not return_responses and os.path.exists(file_path.encode('utf-8')):
+                if not fileobj and not return_responses and not stdout \
+                        and os.path.exists(file_path.encode('utf-8')):
                     st = os.stat(file_path.encode('utf-8'))
                     if st.st_mtime == last_mod_mtime:
                         if self.name == f'{self.identifier}_files.xml' or (st.st_size == self.size):
@@ -413,7 +419,11 @@ class File(BaseFile):
                 break
             except (RetryError, HTTPError, ConnectTimeout, OSError, ReadTimeout,
                     exceptions.InvalidChecksumError) as exc:
-                if retries > 0:
+                # A 416 (Range Not Satisfiable) is a permanent response to an
+                # explicit range request -- retrying cannot help, so fail fast.
+                resp = getattr(exc, 'response', None)
+                unsatisfiable = getattr(resp, 'status_code', None) == 416
+                if retries > 0 and not unsatisfiable:
                     retrying = True
                     retries -= 1
                     msg = ('download failed, sleeping for '
@@ -422,12 +432,21 @@ class File(BaseFile):
                     log.warning(msg)
                     sleep(retries_sleep)
                     continue
-                msg = f'error downloading file {file_path}, exception raised: {exc}'
+                if unsatisfiable:
+                    valid = resp.headers.get('Content-Range', '')
+                    rng = headers.get('Range', '')
+                    msg = (f'error downloading {file_path}: requested range '
+                           f'{rng!r} not satisfiable'
+                           + (f' (file is {valid})' if valid else ''))
+                else:
+                    msg = f'error downloading file {file_path}, exception raised: {exc}'
                 log.error(msg)
-                try:
-                    os.remove(file_path)
-                except OSError:
-                    pass
+                # Never touch the local filesystem for a stdout download.
+                if not stdout:
+                    try:
+                        os.remove(file_path)
+                    except OSError:
+                        pass
                 if verbose:
                     print(f' {msg}', file=sys.stderr)
                 if ignore_errors:

--- a/internetarchive/item.py
+++ b/internetarchive/item.py
@@ -711,6 +711,53 @@ class Item(BaseItem):
                         if not any(fnmatch(f.get('name', ''), e) for e in exclude_patterns):
                             yield self.get_file(str(f.get('name')))
 
+    def _download_range_jobs(
+        self,
+        range_jobs: list[tuple[str, str]],
+        **kwargs,
+    ) -> list[Request | Response]:
+        """Stream partial (byte-range) downloads for an ordered list of jobs.
+
+        Each job is a ``(filename, range_header_value)`` tuple. Jobs are written
+        in order with **no** separator between them (``ors=False``), so the bytes
+        returned by the server are concatenated raw -- concatenated gzip members
+        (e.g. ``.warc.gz`` records) stay byte-adjacent and can be piped to
+        ``zcat``. The same file may appear more than once.
+
+        :param range_jobs: Ordered ``(filename, "bytes=...")`` tuples.
+        :param kwargs: Download options forwarded to :meth:`File.download`.
+        :returns: A list of responses if ``return_responses`` is set, else ``[]``.
+        """
+        responses = []
+        for name, byte_range in range_jobs:
+            f = self.get_file(name)
+            if kwargs.get("dry_run"):
+                print(f.url)
+                continue
+            r = f.download(
+                f.name,
+                kwargs.get("verbose"),
+                kwargs.get("ignore_existing"),
+                kwargs.get("checksum"),
+                kwargs.get("checksum_archive"),
+                kwargs.get("destdir"),
+                kwargs.get("retries"),
+                kwargs.get("ignore_errors"),
+                kwargs.get("fileobj"),
+                kwargs.get("return_responses"),
+                kwargs.get("no_change_timestamp"),
+                kwargs.get("params"),
+                None,  # chunk_size
+                kwargs.get("stdout"),
+                False,  # ors -- raw concatenation, no separator between segments
+                kwargs.get("timeout"),
+                headers={"Range": byte_range},
+                count_views=kwargs.get("count_views", False),
+            )
+            if kwargs.get("return_responses"):
+                responses.append(r)
+        return responses
+
     # ruff: noqa: PLR0912, PLR0913
     def download(self,
                  files: File | list[File] | None = None,
@@ -738,6 +785,7 @@ class Item(BaseItem):
                  timeout: float | tuple[int, float] | None = None,
                  count_views: bool = False,
                  headers: Mapping | None = None,
+                 range_jobs: list[tuple[str, str]] | None = None,
                  ) -> list[Request | Response]:
         """Download files from an item.
 
@@ -814,6 +862,15 @@ class Item(BaseItem):
                         partial fetch, skipping resume and full-file checksum
                         validation.
 
+        :param range_jobs: An ordered list of ``(filename, range_header_value)``
+                           tuples for partial (byte-range) downloads, e.g.
+                           ``[('a.warc.gz', 'bytes=0-1023')]``. Intended for use
+                           with ``stdout=True``: each job is streamed in order
+                           with **no** separator between them (raw
+                           concatenation), so the same file may appear more than
+                           once. When set, this supersedes ``files``/``formats``/
+                           ``glob_pattern`` selection.
+
         :param ignore_history_dir: Do not download any files from the history
                                    dir. This param defaults to ``False``.
 
@@ -860,6 +917,17 @@ class Item(BaseItem):
             if verbose:
                 print(f' {msg}', file=sys.stderr)
             return []
+
+        if range_jobs:
+            return self._download_range_jobs(
+                range_jobs, verbose=verbose, ignore_existing=ignore_existing,
+                checksum=checksum, checksum_archive=checksum_archive,
+                destdir=destdir, retries=retries, ignore_errors=ignore_errors,
+                fileobj=fileobj, return_responses=return_responses,
+                no_change_timestamp=no_change_timestamp, params=params,
+                stdout=stdout, timeout=timeout, count_views=count_views,
+                dry_run=dry_run,
+            )
 
         if files:
             files = self.get_files(files, on_the_fly=on_the_fly)

--- a/internetarchive/item.py
+++ b/internetarchive/item.py
@@ -711,7 +711,7 @@ class Item(BaseItem):
                         if not any(fnmatch(f.get('name', ''), e) for e in exclude_patterns):
                             yield self.get_file(str(f.get('name')))
 
-    # ruff: noqa: PLR0912
+    # ruff: noqa: PLR0912, PLR0913
     def download(self,
                  files: File | list[File] | None = None,
                  formats: str | list[str] | None = None,
@@ -737,6 +737,7 @@ class Item(BaseItem):
                  params: Mapping | None = None,
                  timeout: float | tuple[int, float] | None = None,
                  count_views: bool = False,
+                 headers: Mapping | None = None,
                  ) -> list[Request | Response]:
         """Download files from an item.
 
@@ -806,6 +807,12 @@ class Item(BaseItem):
 
         :param count_views: If True, omit the default ``cnt=0`` parameter so
                             downloads count toward archive.org view counts.
+
+        :param headers: Extra HTTP headers to send with each download request.
+                        Supplying a ``Range`` header (e.g.
+                        ``{'Range': 'bytes=0-1023'}``) performs an intentional
+                        partial fetch, skipping resume and full-file checksum
+                        validation.
 
         :param ignore_history_dir: Do not download any files from the history
                                    dir. This param defaults to ``False``.
@@ -903,7 +910,7 @@ class Item(BaseItem):
                 r = f.download(path, verbose, ignore_existing, checksum, checksum_archive,
                                destdir, retries, ignore_errors, fileobj, return_responses,
                                no_change_timestamp, params, None, stdout, ors, timeout,
-                               count_views=count_views)
+                               headers=headers, count_views=count_views)
             except exceptions.DirectoryTraversalError as exc:  # type: ignore
                 # Record error and continue; do not abort entire download batch.
                 msg = f'error: {exc}'

--- a/internetarchive/item.py
+++ b/internetarchive/item.py
@@ -714,6 +714,7 @@ class Item(BaseItem):
     def _download_range_jobs(
         self,
         range_jobs: list[tuple[str, str]],
+        headers: Mapping | None = None,
         **kwargs,
     ) -> list[Request | Response]:
         """Stream partial (byte-range) downloads for an ordered list of jobs.
@@ -725,10 +726,17 @@ class Item(BaseItem):
         ``zcat``. The same file may appear more than once.
 
         :param range_jobs: Ordered ``(filename, "bytes=...")`` tuples.
+        :param headers: Extra HTTP headers merged into each request (the per-job
+                        ``Range`` header takes precedence).
         :param kwargs: Download options forwarded to :meth:`File.download`.
-        :returns: A list of responses if ``return_responses`` is set, else ``[]``.
+        :returns: A list of responses if ``return_responses`` is set, else a list
+                  of the filenames whose download failed (empty if all succeeded),
+                  mirroring :meth:`download`.
         """
+        base_headers = dict(headers) if headers else {}
+        return_responses = kwargs.get("return_responses")
         responses = []
+        errors = []
         for name, byte_range in range_jobs:
             f = self.get_file(name)
             if kwargs.get("dry_run"):
@@ -736,27 +744,28 @@ class Item(BaseItem):
                 continue
             r = f.download(
                 f.name,
-                kwargs.get("verbose"),
-                kwargs.get("ignore_existing"),
-                kwargs.get("checksum"),
-                kwargs.get("checksum_archive"),
-                kwargs.get("destdir"),
-                kwargs.get("retries"),
-                kwargs.get("ignore_errors"),
-                kwargs.get("fileobj"),
-                kwargs.get("return_responses"),
-                kwargs.get("no_change_timestamp"),
-                kwargs.get("params"),
-                None,  # chunk_size
-                kwargs.get("stdout"),
-                False,  # ors -- raw concatenation, no separator between segments
-                kwargs.get("timeout"),
-                headers={"Range": byte_range},
+                verbose=kwargs.get("verbose"),
+                ignore_existing=kwargs.get("ignore_existing"),
+                checksum=kwargs.get("checksum"),
+                checksum_archive=kwargs.get("checksum_archive"),
+                destdir=kwargs.get("destdir"),
+                retries=kwargs.get("retries"),
+                ignore_errors=kwargs.get("ignore_errors"),
+                fileobj=kwargs.get("fileobj"),
+                return_responses=return_responses,
+                no_change_timestamp=kwargs.get("no_change_timestamp"),
+                params=kwargs.get("params"),
+                stdout=kwargs.get("stdout"),
+                ors=False,  # raw concatenation, no separator between segments
+                timeout=kwargs.get("timeout"),
+                headers={**base_headers, "Range": byte_range},
                 count_views=kwargs.get("count_views", False),
             )
-            if kwargs.get("return_responses"):
+            if return_responses:
                 responses.append(r)
-        return responses
+            if r is False:
+                errors.append(f.name)
+        return responses if return_responses else errors
 
     # ruff: noqa: PLR0912, PLR0913
     def download(self,
@@ -920,10 +929,11 @@ class Item(BaseItem):
 
         if range_jobs:
             return self._download_range_jobs(
-                range_jobs, verbose=verbose, ignore_existing=ignore_existing,
-                checksum=checksum, checksum_archive=checksum_archive,
-                destdir=destdir, retries=retries, ignore_errors=ignore_errors,
-                fileobj=fileobj, return_responses=return_responses,
+                range_jobs, headers=headers, verbose=verbose,
+                ignore_existing=ignore_existing, checksum=checksum,
+                checksum_archive=checksum_archive, destdir=destdir,
+                retries=retries, ignore_errors=ignore_errors, fileobj=fileobj,
+                return_responses=return_responses,
                 no_change_timestamp=no_change_timestamp, params=params,
                 stdout=stdout, timeout=timeout, count_views=count_views,
                 dry_run=dry_run,

--- a/tests/cli/test_ia_download.py
+++ b/tests/cli/test_ia_download.py
@@ -266,16 +266,95 @@ def test_normalize_byte_range_invalid(value):
         normalize_byte_range(value)
 
 
-def test_range_flag_sends_range_header(tmpdir_ch):
+def _range_headers(rsps):
+    """Return the Range header of every download request, in call order."""
+    return [c.request.headers['Range']
+            for c in rsps.calls if 'Range' in c.request.headers]
+
+
+def test_range_single_bare(tmpdir_ch):
     download_url_re = re.compile(r'https?://archive.org/download/.*')
     with IaRequestsMock(assert_all_requests_are_fired=False) as rsps:
         rsps.add_metadata_mock('nasa')
         rsps.add(responses.GET, download_url_re, body='test')
-        ia_call(['ia', '--insecure', 'download', '--no-directories',
+        ia_call(['ia', '--insecure', 'download', '--no-directories', '--stdout',
                  '--range', '0-3', 'nasa', 'nasa_meta.xml'])
-        assert rsps.calls[-1].request.headers.get('Range') == 'bytes=0-3'
+        assert _range_headers(rsps) == ['bytes=0-3']
 
 
-def test_range_flag_rejects_invalid_range():
-    ia_call(['ia', '--insecure', 'download', 'nasa', 'nasa_meta.xml',
-             '--range', 'not-a-range'], expected_exit_code=2)
+def test_range_bare_multi_range_one_file(tmpdir_ch):
+    download_url_re = re.compile(r'https?://archive.org/download/.*')
+    with IaRequestsMock(assert_all_requests_are_fired=False) as rsps:
+        rsps.add_metadata_mock('nasa')
+        rsps.add(responses.GET, download_url_re, body='AAAA')
+        rsps.add(responses.GET, download_url_re, body='BBBB')
+        ia_call(['ia', '--insecure', 'download', '--no-directories', '--stdout',
+                 '--range', '0-3', '--range', '5-9', 'nasa', 'nasa_meta.xml'])
+        # Both ranges, same file, in flag order.
+        assert _range_headers(rsps) == ['bytes=0-3', 'bytes=5-9']
+
+
+def test_range_bare_single_range_multi_file(tmpdir_ch):
+    download_url_re = re.compile(r'https?://archive.org/download/.*')
+    with IaRequestsMock(assert_all_requests_are_fired=False) as rsps:
+        rsps.add_metadata_mock('nasa')
+        rsps.add(responses.GET, download_url_re, body='AAAA')
+        rsps.add(responses.GET, download_url_re, body='BBBB')
+        ia_call(['ia', '--insecure', 'download', '--no-directories', '--stdout',
+                 '--range', '0-3', 'nasa', 'nasa_meta.xml', 'globe_west_540.jpg'])
+        # Same range applied to each file, in file order.
+        assert _range_headers(rsps) == ['bytes=0-3', 'bytes=0-3']
+        urls = [c.request.url for c in rsps.calls if 'Range' in c.request.headers]
+        assert 'nasa_meta.xml' in urls[0]
+        assert 'globe_west_540.jpg' in urls[1]
+
+
+def test_range_file_form_multi_file(tmpdir_ch):
+    download_url_re = re.compile(r'https?://archive.org/download/.*')
+    with IaRequestsMock(assert_all_requests_are_fired=False) as rsps:
+        rsps.add_metadata_mock('nasa')
+        rsps.add(responses.GET, download_url_re, body='AAAA')
+        rsps.add(responses.GET, download_url_re, body='BBBB')
+        ia_call(['ia', '--insecure', 'download', '--no-directories', '--stdout',
+                 '--range', 'nasa_meta.xml:0-3',
+                 '--range', 'globe_west_540.jpg:5-9', 'nasa'])
+        assert _range_headers(rsps) == ['bytes=0-3', 'bytes=5-9']
+        urls = [c.request.url for c in rsps.calls if 'Range' in c.request.headers]
+        assert 'nasa_meta.xml' in urls[0]
+        assert 'globe_west_540.jpg' in urls[1]
+
+
+def test_range_file_form_same_file_repeated(tmpdir_ch):
+    download_url_re = re.compile(r'https?://archive.org/download/.*')
+    with IaRequestsMock(assert_all_requests_are_fired=False) as rsps:
+        rsps.add_metadata_mock('nasa')
+        rsps.add(responses.GET, download_url_re, body='AAAA')
+        rsps.add(responses.GET, download_url_re, body='BBBB')
+        ia_call(['ia', '--insecure', 'download', '--no-directories', '--stdout',
+                 '--range', 'nasa_meta.xml:0-3',
+                 '--range', 'nasa_meta.xml:5-9', 'nasa'])
+        assert _range_headers(rsps) == ['bytes=0-3', 'bytes=5-9']
+
+
+@pytest.mark.parametrize('argv', [
+    # --range requires --stdout
+    ['ia', '--insecure', 'download', 'nasa', 'nasa_meta.xml', '--range', '0-3'],
+    # bare range with no file to bind to
+    ['ia', '--insecure', 'download', '--stdout', 'nasa', '--range', '0-3'],
+    # multiple bare ranges with multiple files is ambiguous
+    ['ia', '--insecure', 'download', '--stdout', 'nasa', 'a', 'b',
+     '--range', '0-3', '--range', '5-9'],
+    # cannot mix bare and FILE: forms
+    ['ia', '--insecure', 'download', '--stdout', 'nasa',
+     '--range', '0-3', '--range', 'f:5-9'],
+    # FILE: form cannot combine with selectors
+    ['ia', '--insecure', 'download', '--stdout', 'nasa',
+     '--glob', '*', '--range', 'f:0-3'],
+    ['ia', '--insecure', 'download', '--stdout', '--itemlist', '/dev/null',
+     '--range', 'f:0-3'],
+    # invalid range value
+    ['ia', '--insecure', 'download', '--stdout', 'nasa', 'nasa_meta.xml',
+     '--range', 'not-a-range'],
+])
+def test_range_invalid_invocations(argv):
+    ia_call(argv, expected_exit_code=2)

--- a/tests/cli/test_ia_download.py
+++ b/tests/cli/test_ia_download.py
@@ -7,7 +7,7 @@ import pytest
 import responses
 
 from internetarchive import get_item
-from internetarchive.cli.ia_download import normalize_byte_range
+from internetarchive.cli.ia_download import normalize_byte_range, parse_byte_ranges
 from internetarchive.utils import json
 from tests.conftest import (
     NASA_EXPECTED_FILES,
@@ -253,6 +253,8 @@ def test_default_sends_cnt_zero(tmpdir_ch):
     ('0-1023', 'bytes=0-1023'),
     ('bytes=0-1023', 'bytes=0-1023'),
     ('1024-', 'bytes=1024-'),
+    ('-5', 'bytes=-5'),
+    ('bytes=-1024', 'bytes=-1024'),
     (' 0-100 ', 'bytes=0-100'),
     ('BYTES=5-9', 'bytes=5-9'),
 ])
@@ -260,10 +262,26 @@ def test_normalize_byte_range_valid(value, expected):
     assert normalize_byte_range(value) == expected
 
 
-@pytest.mark.parametrize('value', ['abc', '-5', '5-1', '', 'bytes=', '0-1-2'])
+@pytest.mark.parametrize('value', ['abc', '-', '5-1', '', 'bytes=', '0-1-2'])
 def test_normalize_byte_range_invalid(value):
     with pytest.raises(ValueError, match='range'):
         normalize_byte_range(value)
+
+
+@pytest.mark.parametrize(('value', 'expected'), [
+    ('0-9', ['bytes=0-9']),
+    ('0-9,50-99', ['bytes=0-9', 'bytes=50-99']),
+    ('bytes=0-9,-100', ['bytes=0-9', 'bytes=-100']),
+    (' 0-9 , 50-99 ', ['bytes=0-9', 'bytes=50-99']),
+])
+def test_parse_byte_ranges_valid(value, expected):
+    assert parse_byte_ranges(value) == expected
+
+
+@pytest.mark.parametrize('value', ['', '0-9,', ',', '0-9,abc', '0-9,,50-99'])
+def test_parse_byte_ranges_invalid(value):
+    with pytest.raises(ValueError, match='range'):
+        parse_byte_ranges(value)
 
 
 def _range_headers(rsps):
@@ -282,6 +300,16 @@ def test_range_single_bare(tmpdir_ch):
         assert _range_headers(rsps) == ['bytes=0-3']
 
 
+def test_range_suffix_bare(tmpdir_ch):
+    download_url_re = re.compile(r'https?://archive.org/download/.*')
+    with IaRequestsMock(assert_all_requests_are_fired=False) as rsps:
+        rsps.add_metadata_mock('nasa')
+        rsps.add(responses.GET, download_url_re, body='test')
+        ia_call(['ia', '--insecure', 'download', '--no-directories', '--stdout',
+                 '--range', '-100', 'nasa', 'nasa_meta.xml'])
+        assert _range_headers(rsps) == ['bytes=-100']
+
+
 def test_range_bare_multi_range_one_file(tmpdir_ch):
     download_url_re = re.compile(r'https?://archive.org/download/.*')
     with IaRequestsMock(assert_all_requests_are_fired=False) as rsps:
@@ -292,6 +320,32 @@ def test_range_bare_multi_range_one_file(tmpdir_ch):
                  '--range', '0-3', '--range', '5-9', 'nasa', 'nasa_meta.xml'])
         # Both ranges, same file, in flag order.
         assert _range_headers(rsps) == ['bytes=0-3', 'bytes=5-9']
+
+
+def test_range_bare_comma_one_file(tmpdir_ch):
+    download_url_re = re.compile(r'https?://archive.org/download/.*')
+    with IaRequestsMock(assert_all_requests_are_fired=False) as rsps:
+        rsps.add_metadata_mock('nasa')
+        rsps.add(responses.GET, download_url_re, body='AAAA')
+        rsps.add(responses.GET, download_url_re, body='BBBB')
+        ia_call(['ia', '--insecure', 'download', '--no-directories', '--stdout',
+                 '--range', '0-3,5-9', 'nasa', 'nasa_meta.xml'])
+        # A comma list expands to one request per range, in order -- identical
+        # to repeating --range.
+        assert _range_headers(rsps) == ['bytes=0-3', 'bytes=5-9']
+
+
+def test_range_file_form_comma(tmpdir_ch):
+    download_url_re = re.compile(r'https?://archive.org/download/.*')
+    with IaRequestsMock(assert_all_requests_are_fired=False) as rsps:
+        rsps.add_metadata_mock('nasa')
+        rsps.add(responses.GET, download_url_re, body='AAAA')
+        rsps.add(responses.GET, download_url_re, body='BBBB')
+        ia_call(['ia', '--insecure', 'download', '--no-directories', '--stdout',
+                 '--range', 'nasa_meta.xml:0-3,5-9', 'nasa'])
+        assert _range_headers(rsps) == ['bytes=0-3', 'bytes=5-9']
+        urls = [c.request.url for c in rsps.calls if 'Range' in c.request.headers]
+        assert all('nasa_meta.xml' in u for u in urls)
 
 
 def test_range_bare_single_range_multi_file(tmpdir_ch):
@@ -344,6 +398,9 @@ def test_range_file_form_same_file_repeated(tmpdir_ch):
     # multiple bare ranges with multiple files is ambiguous
     ['ia', '--insecure', 'download', '--stdout', 'nasa', 'a', 'b',
      '--range', '0-3', '--range', '5-9'],
+    # a comma list is multiple ranges too -- still ambiguous with multiple files
+    ['ia', '--insecure', 'download', '--stdout', 'nasa', 'a', 'b',
+     '--range', '0-3,5-9'],
     # cannot mix bare and FILE: forms
     ['ia', '--insecure', 'download', '--stdout', 'nasa',
      '--range', '0-3', '--range', 'f:5-9'],
@@ -352,6 +409,8 @@ def test_range_file_form_same_file_repeated(tmpdir_ch):
      '--glob', '*', '--range', 'f:0-3'],
     ['ia', '--insecure', 'download', '--stdout', '--itemlist', '/dev/null',
      '--range', 'f:0-3'],
+    # cannot read identifiers from stdin with --range
+    ['ia', '--insecure', 'download', '--stdout', '-', '--range', 'f:0-3'],
     # invalid range value
     ['ia', '--insecure', 'download', '--stdout', 'nasa', 'nasa_meta.xml',
      '--range', 'not-a-range'],

--- a/tests/cli/test_ia_download.py
+++ b/tests/cli/test_ia_download.py
@@ -7,6 +7,7 @@ import pytest
 import responses
 
 from internetarchive import get_item
+from internetarchive.cli.ia_download import normalize_byte_range
 from internetarchive.utils import json
 from tests.conftest import (
     NASA_EXPECTED_FILES,
@@ -246,3 +247,35 @@ def test_default_sends_cnt_zero(tmpdir_ch):
         ia_call(['ia', '--insecure', 'download', '--no-directories',
                  'nasa', 'nasa_meta.xml'])
         assert 'cnt=0' in rsps.calls[-1].request.url
+
+
+@pytest.mark.parametrize(('value', 'expected'), [
+    ('0-1023', 'bytes=0-1023'),
+    ('bytes=0-1023', 'bytes=0-1023'),
+    ('1024-', 'bytes=1024-'),
+    (' 0-100 ', 'bytes=0-100'),
+    ('BYTES=5-9', 'bytes=5-9'),
+])
+def test_normalize_byte_range_valid(value, expected):
+    assert normalize_byte_range(value) == expected
+
+
+@pytest.mark.parametrize('value', ['abc', '-5', '5-1', '', 'bytes=', '0-1-2'])
+def test_normalize_byte_range_invalid(value):
+    with pytest.raises(ValueError, match='range'):
+        normalize_byte_range(value)
+
+
+def test_range_flag_sends_range_header(tmpdir_ch):
+    download_url_re = re.compile(r'https?://archive.org/download/.*')
+    with IaRequestsMock(assert_all_requests_are_fired=False) as rsps:
+        rsps.add_metadata_mock('nasa')
+        rsps.add(responses.GET, download_url_re, body='test')
+        ia_call(['ia', '--insecure', 'download', '--no-directories',
+                 '--range', '0-3', 'nasa', 'nasa_meta.xml'])
+        assert rsps.calls[-1].request.headers.get('Range') == 'bytes=0-3'
+
+
+def test_range_flag_rejects_invalid_range():
+    ia_call(['ia', '--insecure', 'download', 'nasa', 'nasa_meta.xml',
+             '--range', 'not-a-range'], expected_exit_code=2)

--- a/tests/cli/test_ia_download.py
+++ b/tests/cli/test_ia_download.py
@@ -1,3 +1,4 @@
+import argparse
 import os
 import re
 import sys
@@ -7,7 +8,11 @@ import pytest
 import responses
 
 from internetarchive import get_item
-from internetarchive.cli.ia_download import normalize_byte_range, parse_byte_ranges
+from internetarchive.cli.ia_download import (
+    build_range_jobs,
+    normalize_byte_range,
+    parse_byte_ranges,
+)
 from internetarchive.utils import json
 from tests.conftest import (
     NASA_EXPECTED_FILES,
@@ -417,3 +422,34 @@ def test_range_file_form_same_file_repeated(tmpdir_ch):
 ])
 def test_range_invalid_invocations(argv):
     ia_call(argv, expected_exit_code=2)
+
+
+def test_range_job_failure_exits_nonzero(tmpdir_ch):
+    """A failed range segment must propagate a nonzero exit code, so a downstream
+    pipe consumer can tell the bytes are incomplete."""
+    download_url_re = re.compile(r'https?://archive.org/download/.*')
+    with IaRequestsMock(assert_all_requests_are_fired=False) as rsps:
+        rsps.add_metadata_mock('nasa')
+        rsps.add(responses.GET, download_url_re,
+                 status=416,
+                 adding_headers={'Content-Range': 'bytes */7105'})
+        ia_call(['ia', '--insecure', 'download', '--no-directories', '--stdout',
+                 '--range', '99999999-', 'nasa', 'nasa_meta.xml'],
+                expected_exit_code=1)
+
+
+def _range_args(ranges, identifier='nasa', file=None):
+    """Build a minimal argparse.Namespace for build_range_jobs unit tests."""
+    return argparse.Namespace(
+        identifier=identifier, file=file or [], glob=None, format=None,
+        source=None, exclude_source=None, search=None, itemlist=None,
+        ranges=ranges,
+    )
+
+
+def test_build_range_jobs_filename_with_colon():
+    """A FILE:RANGE value whose filename itself contains a colon binds to the
+    full filename (split on the last colon)."""
+    parser = argparse.ArgumentParser()
+    args = _range_args(['weird:name.warc.gz:0-9'])
+    assert build_range_jobs(args, parser) == [('weird:name.warc.gz', 'bytes=0-9')]

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 
 import pytest
 import responses
-from requests.exceptions import HTTPError
+from requests.exceptions import HTTPError, ReadTimeout
 
 from internetarchive.exceptions import DirectoryTraversalError
 from internetarchive.utils import sanitize_filename
@@ -225,3 +225,152 @@ def test_stdout_ignores_local_file_no_resume_or_skip(tmpdir, nasa_item, capfd):
 
     # ...and the full body went to stdout (not skipped, not appended locally).
     assert capfd.readouterr().out == 'test'
+
+
+def test_stdout_retry_writes_to_stdout_not_local_file(tmpdir, nasa_item, capfd,
+                                                      monkeypatch):
+    """A retried stdout download must keep writing to stdout, never fall back to
+    creating a local disk file (which would leave the pipe empty).
+
+    The first request raises a caught error to drive File.download's own retry
+    loop (the ``retrying`` path); the retry then streams the body.
+    """
+    monkeypatch.setattr('internetarchive.files.sleep', lambda s: None)
+    tmpdir.chdir()
+    file_obj = nasa_item.get_file('nasa_meta.xml')
+
+    class _Resp:
+        def __init__(self, chunks):
+            self._chunks = chunks
+            self.headers = {}
+
+        def raise_for_status(self):
+            pass
+
+        def iter_content(self, chunk_size):
+            yield from self._chunks
+
+    seq = [ReadTimeout('boom'), _Resp([b'test'])]
+
+    def fake_get(url, **kwargs):
+        item = seq.pop(0)
+        if isinstance(item, Exception):
+            raise item
+        return item
+
+    monkeypatch.setattr(file_obj.item.session, 'get', fake_get)
+
+    result = file_obj.download(stdout=True, retries=1)
+
+    assert result is True
+    # The body reached stdout on the retry...
+    assert capfd.readouterr().out == 'test'
+    # ...and no local file was created as a side effect of the retry.
+    assert not os.path.exists(os.path.join(str(tmpdir), 'nasa_meta.xml'))
+
+
+def test_resume_retry_recomputes_range_from_current_size(tmpdir, nasa_item,
+                                                         monkeypatch):
+    """On a retried auto-resume, the internal Range header must track the (grown)
+    local file size so it stays aligned with the seek offset. A stale Range from
+    the previous attempt would re-fetch already-written bytes and corrupt the file.
+    """
+    monkeypatch.setattr('internetarchive.files.sleep', lambda s: None)
+    tmpdir.chdir()
+    file_obj = nasa_item.get_file('nasa_meta.xml')
+    local = os.path.join(str(tmpdir), 'nasa_meta.xml')
+    with open(local, 'wb') as fh:
+        fh.write(b'X' * 100)  # partial; remote size differs -> triggers resume
+    assert file_obj.size != 100
+
+    sent_ranges = []
+
+    class _Resp:
+        def __init__(self, chunks, exc=None):
+            self._chunks = chunks
+            self._exc = exc
+            self.headers = {}
+
+        def raise_for_status(self):
+            pass
+
+        def iter_content(self, chunk_size):
+            yield from self._chunks
+            if self._exc:
+                raise self._exc
+
+    seq = [
+        _Resp([b'ABCDE'], exc=ReadTimeout('boom')),  # writes 5 bytes then fails
+        _Resp([b'rest-of-data']),                     # completes (checksum fails)
+    ]
+
+    def fake_get(url, **kwargs):
+        sent_ranges.append(kwargs['headers'].get('Range'))
+        return seq.pop(0)
+
+    monkeypatch.setattr(file_obj.item.session, 'get', fake_get)
+
+    # ignore_errors so the final (expected) checksum mismatch returns False
+    # rather than raising; we only care about the Range headers that were sent.
+    file_obj.download(destdir=str(tmpdir), retries=1, ignore_errors=True)
+
+    # Attempt 1 resumed from 100; after writing 5 bytes the local file is 105,
+    # so the retry must request bytes=105- (not the stale bytes=100-).
+    assert sent_ranges == ['bytes=100-', 'bytes=105-']
+
+
+def test_lowercase_range_header_suppresses_resume(tmpdir, nasa_item, monkeypatch):
+    """A caller-supplied lowercase 'range' header is still an explicit range and
+    must suppress auto-resume -- it must not be clobbered by a
+    bytes=<localsize>- resume header (the check is case-insensitive)."""
+    monkeypatch.setattr('internetarchive.files.sleep', lambda s: None)
+    tmpdir.chdir()
+    file_obj = nasa_item.get_file('nasa_meta.xml')
+    local = os.path.join(str(tmpdir), 'nasa_meta.xml')
+    with open(local, 'wb') as fh:
+        fh.write(b'X' * 100)  # partial -> would normally trigger auto-resume
+
+    with IaRequestsMock(assert_all_requests_are_fired=False) as rsps:
+        rsps.add(responses.GET, DOWNLOAD_URL_RE,
+                 body='test',
+                 adding_headers=EXPECTED_LAST_MOD_HEADER)
+        file_obj.download(destdir=str(tmpdir), ignore_errors=True,
+                          headers={'range': 'bytes=5-8'})
+        # The caller's explicit (lowercase) range was sent unchanged on the first
+        # request; no auto-resume bytes=100- header overrode it.
+        range_vals = [v for k, v in rsps.calls[0].request.headers.items()
+                      if k.lower() == 'range']
+
+    assert range_vals == ['bytes=5-8']
+
+
+def test_range_jobs_forward_caller_headers(nasa_item):
+    """Caller-supplied headers (e.g. If-Match) are merged with the per-job Range
+    header and sent on each range request."""
+    with IaRequestsMock(assert_all_requests_are_fired=False) as rsps:
+        rsps.add(responses.GET, DOWNLOAD_URL_RE, body='AAAA')
+        nasa_item.download(
+            range_jobs=[('nasa_meta.xml', 'bytes=0-3')],
+            headers={'If-Match': '"etag123"'},
+            stdout=True,
+        )
+        req = rsps.calls[-1].request
+
+    assert req.headers.get('Range') == 'bytes=0-3'
+    assert req.headers.get('If-Match') == '"etag123"'
+
+
+def test_range_jobs_surface_download_errors(nasa_item):
+    """A failed range segment (ignore_errors=True -> File.download returns False)
+    must be surfaced in the returned errors list, not silently dropped."""
+    with IaRequestsMock(assert_all_requests_are_fired=False) as rsps:
+        rsps.add(responses.GET, DOWNLOAD_URL_RE,
+                 status=416,
+                 adding_headers={'Content-Range': 'bytes */7105'})
+        errors = nasa_item.download(
+            range_jobs=[('nasa_meta.xml', 'bytes=99999999-')],
+            stdout=True,
+            ignore_errors=True,
+        )
+
+    assert errors == ['nasa_meta.xml']

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -113,6 +113,35 @@ def test_item_download_headers_propagate(tmpdir, nasa_item):
         assert rsps.calls[-1].request.headers.get('Range') == 'bytes=0-3'
 
 
+def test_item_download_range_jobs_no_separator(nasa_item, capfd):
+    """Range segments are concatenated raw to stdout -- no ORS between them, so
+    e.g. gzip members stay byte-adjacent."""
+    with IaRequestsMock(assert_all_requests_are_fired=False) as rsps:
+        rsps.add(responses.GET, DOWNLOAD_URL_RE, body='AAAA')
+        rsps.add(responses.GET, DOWNLOAD_URL_RE, body='BBBB')
+        nasa_item.download(
+            range_jobs=[('nasa_meta.xml', 'bytes=0-3'),
+                        ('nasa_meta.xml', 'bytes=5-9')],
+            stdout=True,
+        )
+    out = capfd.readouterr().out
+    assert out == 'AAAABBBB'  # no '\n' (or any) separator between segments
+
+
+def test_item_download_range_jobs_sends_ranges_in_order(nasa_item):
+    with IaRequestsMock(assert_all_requests_are_fired=False) as rsps:
+        rsps.add(responses.GET, DOWNLOAD_URL_RE, body='AAAA')
+        rsps.add(responses.GET, DOWNLOAD_URL_RE, body='BBBB')
+        nasa_item.download(
+            range_jobs=[('nasa_meta.xml', 'bytes=0-3'),
+                        ('nasa_meta.xml', 'bytes=5-9')],
+            stdout=True,
+        )
+        ranges = [c.request.headers['Range']
+                  for c in rsps.calls if 'Range' in c.request.headers]
+        assert ranges == ['bytes=0-3', 'bytes=5-9']
+
+
 def test_file_download_explicit_range_skips_resume(tmpdir, nasa_item):
     """An explicit Range must not trigger resume (seek/append) or the
     full-file checksum validation, even when a shorter local file exists.

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -88,3 +88,56 @@ def test_item_download_count_views_propagates(tmpdir, nasa_item):
                            destdir=str(tmpdir),
                            count_views=True)
         assert 'cnt=' not in rsps.calls[-1].request.url
+
+
+def test_file_download_sends_range_header(tmpdir, nasa_item):
+    tmpdir.chdir()
+    with IaRequestsMock(assert_all_requests_are_fired=False) as rsps:
+        rsps.add(responses.GET, DOWNLOAD_URL_RE,
+                 body='test',
+                 adding_headers=EXPECTED_LAST_MOD_HEADER)
+        file_obj = nasa_item.get_file('nasa_meta.xml')
+        file_obj.download(destdir=str(tmpdir), headers={'Range': 'bytes=0-3'})
+        assert rsps.calls[-1].request.headers.get('Range') == 'bytes=0-3'
+
+
+def test_item_download_headers_propagate(tmpdir, nasa_item):
+    tmpdir.chdir()
+    with IaRequestsMock(assert_all_requests_are_fired=False) as rsps:
+        rsps.add(responses.GET, DOWNLOAD_URL_RE,
+                 body='test',
+                 adding_headers=EXPECTED_LAST_MOD_HEADER)
+        nasa_item.download(files=['nasa_meta.xml'],
+                           destdir=str(tmpdir),
+                           headers={'Range': 'bytes=0-3'})
+        assert rsps.calls[-1].request.headers.get('Range') == 'bytes=0-3'
+
+
+def test_file_download_explicit_range_skips_resume(tmpdir, nasa_item):
+    """An explicit Range must not trigger resume (seek/append) or the
+    full-file checksum validation, even when a shorter local file exists.
+    """
+    tmpdir.chdir()
+    file_obj = nasa_item.get_file('nasa_meta.xml')
+    # Pre-create a partial local file whose size differs from the remote size,
+    # which is what normally triggers the auto-resume code path.
+    local_path = os.path.join(str(tmpdir), 'nasa_meta.xml')
+    with open(local_path, 'w') as fh:
+        fh.write('AAAA')
+    assert len('AAAA') != file_obj.size
+
+    with IaRequestsMock(assert_all_requests_are_fired=False) as rsps:
+        rsps.add(responses.GET, DOWNLOAD_URL_RE,
+                 body='test',
+                 adding_headers=EXPECTED_LAST_MOD_HEADER)
+        # Body md5 != file_obj.md5; if resume fired this would raise
+        # InvalidChecksumError. It must not.
+        file_obj.download(destdir=str(tmpdir), headers={'Range': 'bytes=5-8'})
+
+        # The user's Range was sent unchanged (not overwritten by an auto-resume
+        # ``bytes=<localsize>-`` header)...
+        assert rsps.calls[-1].request.headers.get('Range') == 'bytes=5-8'
+
+    # ...and the file was truncated + rewritten ('wb'), not appended to ('rb+').
+    with open(local_path) as fh:
+        assert fh.read() == 'test'

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 
 import pytest
 import responses
+from requests.exceptions import HTTPError
 
 from internetarchive.exceptions import DirectoryTraversalError
 from internetarchive.utils import sanitize_filename
@@ -170,3 +171,57 @@ def test_file_download_explicit_range_skips_resume(tmpdir, nasa_item):
     # ...and the file was truncated + rewritten ('wb'), not appended to ('rb+').
     with open(local_path) as fh:
         assert fh.read() == 'test'
+
+
+def test_range_not_satisfiable_fails_fast(tmpdir, nasa_item):
+    """A 416 (Range Not Satisfiable) is permanent: it must not be retried, and
+    with ignore_errors it returns False rather than raising."""
+    tmpdir.chdir()
+    file_obj = nasa_item.get_file('nasa_meta.xml')
+    with IaRequestsMock(assert_all_requests_are_fired=False) as rsps:
+        rsps.add(responses.GET, DOWNLOAD_URL_RE,
+                 status=416,
+                 adding_headers={'Content-Range': 'bytes */7105'})
+        result = file_obj.download(destdir=str(tmpdir), ignore_errors=True,
+                                   headers={'Range': 'bytes=99999999-'})
+        assert result is False
+        # Exactly one request: the 416 was not retried.
+        assert len(rsps.calls) == 1
+
+
+def test_range_not_satisfiable_raises_without_ignore_errors(tmpdir, nasa_item):
+    tmpdir.chdir()
+    file_obj = nasa_item.get_file('nasa_meta.xml')
+    with IaRequestsMock(assert_all_requests_are_fired=False) as rsps:
+        rsps.add(responses.GET, DOWNLOAD_URL_RE,
+                 status=416,
+                 adding_headers={'Content-Range': 'bytes */7105'})
+        with pytest.raises(HTTPError):
+            file_obj.download(destdir=str(tmpdir),
+                              headers={'Range': 'bytes=99999999-'})
+        assert len(rsps.calls) == 1
+
+
+def test_stdout_ignores_local_file_no_resume_or_skip(tmpdir, nasa_item, capfd):
+    """A stdout download must never consult the local filesystem: no skip,
+    no auto-resume seek/append, regardless of a same-named local file.
+
+    A same-named local file whose size differs from the remote size is what
+    normally triggers the auto-resume path (and seeking a pipe would fail).
+    """
+    tmpdir.chdir()
+    file_obj = nasa_item.get_file('nasa_meta.xml')
+    with open(os.path.join(str(tmpdir), 'nasa_meta.xml'), 'w') as fh:
+        fh.write('AA')
+    assert len('AA') != file_obj.size
+
+    with IaRequestsMock(assert_all_requests_are_fired=False) as rsps:
+        rsps.add(responses.GET, DOWNLOAD_URL_RE,
+                 body='test',
+                 adding_headers=EXPECTED_LAST_MOD_HEADER)
+        file_obj.download(stdout=True)
+        # No auto-resume Range header was sent for the stdout download...
+        assert 'Range' not in rsps.calls[-1].request.headers
+
+    # ...and the full body went to stdout (not skipped, not appended locally).
+    assert capfd.readouterr().out == 'test'


### PR DESCRIPTION
## Summary

Adds a `--range [FILE:]START-END` flag to `ia download` that sends an HTTP `Range`
header, enabling partial (byte-range) downloads of item files. It **requires**
`--stdout`, uses your configured credentials (so private items work), and is
repeatable. Most useful for inspecting part of a (possibly private) file without
fetching the whole thing.

This also makes it possible to extract a single record from a WARC the way the
Wayback stack does: pass the compressed offset/length from a CDX index as a byte
range and pipe through `zcat`.

```console
# from a CDX row's S (length) and V (offset) fields; range is V-(V+S-1):
ia download <item> <file>.warc.gz --stdout --range <V>-$((V + S - 1)) | zcat
```

## The flag

- **Range forms:** `START-END`, open-ended `START-`, suffix `-N` (the last `N`
  bytes), or a `bytes=`-prefixed value. A single value may carry several
  comma-separated ranges (`0-9,50-99`), fetched in order.
- **Binding:** a bare range binds to the file named on the command line (vary
  *either* the range *or* the file, not both at once); `FILE:START-END` binds
  each range to its own file, so you can pull ranges from different files.
- **Output:** segments are streamed back-to-back with **no separator** (unlike a
  normal multi-file `--stdout`, which inserts the ORS), so concatenated gzip
  members stay byte-adjacent.
- **Semantics:** an explicit range is an intentional partial fetch, so resume and
  full-file checksum validation are disabled. An unsatisfiable range (HTTP `416`)
  fails fast with a clear message instead of being retried; a range covering the
  whole file returns the full contents (HTTP `200`). If any segment fails,
  `ia download` exits non-zero so a downstream pipe consumer can tell the output
  is incomplete.

## What changed

- **`files.py` — decouple resume from explicit range.** The download code already
  set a `Range` header internally to *resume* interrupted downloads, keyed off
  `'Range' in headers`. That signal collided with an explicit user range. A
  dedicated `resume` boolean now gates that behavior, and auto-resume only fires
  when the caller did **not** supply a `Range` header (checked case-insensitively).
- **`item.py` / `api.py` — plumb `headers` and `range_jobs`.** Thread a `headers`
  argument through `Item.download()` and the top-level `internetarchive.download()`
  (it already existed on `File.download()`), plus a `range_jobs` argument on
  `Item.download()`.
- **`cli/ia_download.py` — the flag.** Parses/normalizes/validates `--range`
  values into an ordered `(file, bytes=...)` job list.
- Docs (`cli.rst`) and changelog (`HISTORY.rst`).

## Bugfixes (review follow-ups)

Several bugs surfaced reviewing the feature — including a few on its own `--stdout`
happy path — are fixed in this PR, each with a regression test (written test-first):

- **Retried stdout download wrote to a local disk file** instead of the pipe
  (leaving the pipe empty). A stdout download now always writes to stdout, even
  across retries.
- **Auto-resume corrupted a file when a resumed transfer was itself retried** —
  the internal `Range` was not recomputed for the retry, so it no longer matched
  the grown local file or the seek offset and re-fetched already-written bytes.
  The resume `Range` is now recomputed from the current file size every attempt.
- **The explicit-range check was case-sensitive**, so a caller-supplied lowercase
  `range` header was silently clobbered by an auto-resume `Range`. Now
  case-insensitive.
- **Failed `--range` segments were silently swallowed** (the CLI exited 0 while
  emitting incomplete bytes). A failed segment now surfaces as a download error
  and yields a non-zero exit.
- **Caller-supplied `headers` were dropped on the range path**; they are now
  forwarded and merged with the per-segment `Range`.
- A stdout download no longer consults the local filesystem at all (skip / resume
  checks are bypassed for stdout).

## Testing

- `ruff`, `black`, `codespell`, `mypy` clean (pre-commit).
- Full test suite passes (**322 passed, 37 skipped** live-only). New unit tests
  cover `normalize_byte_range` / `parse_byte_ranges` / `build_range_jobs`, mocked
  ranged `--stdout` fetches, range-job ordering and no-separator output, the
  resume/stdout/416 paths, and each of the bugfixes above.
- Verified end-to-end against live archive.org: ranged `--stdout` returns exactly
  the requested bytes, and a CDX offset/length extracts the expected single WARC
  record.

## Known limitation (follow-up)

A `--stdout` download that fails *mid-stream* (after some bytes have already been
written to the pipe) will, on retry, re-stream the segment from the start and emit
duplicate bytes to the consumer. This PR fixes the disk-fallback case; the
"can't un-send piped bytes" case is left as a follow-up (a stdout download should
not retry once bytes have been emitted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
