### PR TITLE
Clean up toolchain drift in dev/test/release tooling

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,25 @@
+# Configures the auto-generated section that `gh release create --generate-notes`
+# appends after the curated HISTORY.rst body.
+# https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes
+changelog:
+  exclude:
+    authors:
+      - dependabot
+      - dependabot[bot]
+      - pre-commit-ci[bot]
+  categories:
+    - title: Features and Improvements
+      labels:
+        - enhancement
+        - feature
+    - title: Bugfixes
+      labels:
+        - bug
+        - bugfix
+    - title: Documentation
+      labels:
+        - documentation
+        - docs
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -15,4 +15,3 @@ jobs:
       - run: ruff check --output-format=github  # See pyproject.toml for configuration
       - run: pip install -r pex-requirements.txt -r tests/requirements.txt
       - run: mypy .  # See setup.cfg for configuration
-      - run: safety check || true  # Temporary fix for https://pyup.io/v/51457/f17

--- a/.gitignore
+++ b/.gitignore
@@ -34,5 +34,3 @@ ia.dist/
 ia.bin
 scripts/
 foo.txt
-plans/
-.worktrees/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
       - id: requirements-txt-fixer
       - id: trailing-whitespace
 
-  - repo: https://github.com/charliermarsh/ruff-pre-commit
+  - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.14.1
 
     hooks:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,8 +10,8 @@ Python library and `ia` CLI for interacting with archive.org. Used for uploading
 ## Common Commands
 
 ```bash
-# Install for development
-pip install -e .
+# Install for development (includes linting, tests, type-checking, and docs tooling)
+pip install -e '.[all]'
 
 # Run tests
 pytest
@@ -61,7 +61,7 @@ Convenience functions that wrap the core classes: `get_item()`, `search_items()`
 
 ## Code Style
 
-- Line length: 90 characters
+- Line length: 102 characters (configured for ruff in `pyproject.toml` and for black in `setup.cfg`)
 - Linter: ruff (configured in `pyproject.toml`)
 - Formatter: black
 - Type checking: mypy (type stubs in `options.extras_require` under `types`)

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -25,7 +25,7 @@ All pull requests and patches are welcome, but please consider the following:
 - Include tests.
 - Include documentation for new features.
 - If your patch is supposed to fix a bug, please describe in as much detail as possible the circumstances in which the bug happens.
-- Please follow `PEP8 <http://legacy.python.org/dev/peps/pep-0008/>`_, with the exception of what is ignored in `setup.cfg <https://github.com/jjjake/internetarchive/blob/master/setup.cfg>`_. PEP8 compliance is checked when tests run. Tests will fail if your patch is not PEP8 compliant.
+- Code style is enforced by `ruff <https://docs.astral.sh/ruff/>`_ (configured in `pyproject.toml <https://github.com/jjjake/internetarchive/blob/master/pyproject.toml>`_). Run ``ruff check`` before submitting; CI will fail if your patch is not clean.
 - Add yourself to AUTHORS.rst.
 - Avoid introducing new dependencies.
 - Open an issue if a relevant one is not already open, so others have visibility into what you're working on and efforts aren't duplicated.
@@ -34,34 +34,28 @@ All pull requests and patches are welcome, but please consider the following:
 Running Tests
 -------------
 
-The minimal requirements for running tests are ``pytest``, ``pytest-pep8`` and ``responses``:
-
-.. code:: bash
-
-    $ pip install pytest pytest-pep8 responses
-
 Clone the `internetarchive lib <https://github.com/jjjake/internetarchive>`_:
 
 .. code:: bash
 
     $ git clone https://github.com/jjjake/internetarchive
 
-Install the `internetarchive lib <https://github.com/jjjake/internetarchive>`_ as an editable package:
+Install it as an editable package with its test dependencies:
 
 .. code:: bash
 
     $ cd internetarchive
-    $ pip install -e .
+    $ pip install -e '.[test]'
 
-Run the tests:
+Run the linter and the tests:
 
 .. code:: bash
 
-    $ py.test --pep8
+    $ ruff check && pytest
 
 Note that this will only test against the Python version you are currently using, however ``internetarchive`` tests against multiple Python versions defined in `tox.ini <https://github.com/jjjake/internetarchive/blob/master/tox.ini>`_. Tests must pass on all versions defined in ``tox.ini`` for all pull requests.
 
-To test against all supported Python versions, first make sure you have all of the required versions of Python installed. Then simply install execute tox from the root directory of the repo:
+To test against all supported Python versions, first make sure you have all of the required versions of Python installed. Then install and execute tox from the root directory of the repo:
 
 .. code:: bash
 

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,12 @@
 .PHONY: docs clean clean-dist test binary test-binary check-release check-version \
-        build tag push-tag upload-pypi publish-binary-upload github-release \
-        publish publish-binary docs-init init pep8-test prepare-release
+        build check-dist tag push-tag upload-pypi publish-binary-upload github-release \
+        publish publish-binary docs-init init prepare-release
 
 VERSION=$(shell grep -m1 __version__ internetarchive/__version__.py | cut -d\' -f2)
 
 # ============ Development ============
 init:
-	pip install responses==0.5.0 pytest-cov pytest-pep8
-	pip install -e .
+	pip install -e '.[all]'
 
 clean:
 	find . -type f -name '*\.pyc' -delete
@@ -15,9 +14,6 @@ clean:
 
 clean-dist:
 	rm -rf dist/ build/ *.egg-info
-
-pep8-test:
-	py.test --pep8 -m pep8 --cov-report term-missing --cov internetarchive
 
 test:
 	ruff check
@@ -79,6 +75,10 @@ check-version:
 build: clean-dist
 	python -m build
 
+# Validate built artifacts (metadata + long_description rendering) before any upload
+check-dist:
+	twine check dist/*
+
 # ============ Release Publishing ============
 tag:
 	git tag -a v$(VERSION) -m 'version $(VERSION)'
@@ -95,13 +95,20 @@ publish-binary-upload:
 	./ia-$(VERSION)-py3-none-any.pex upload ia-pex ia-$(VERSION)-py3-none-any.pex --no-derive
 	./ia-$(VERSION)-py3-none-any.pex upload ia-pex ia-$(VERSION)-py3-none-any.pex --remote-name=ia --no-derive
 
-# Extract changelog and create GitHub release
+# Extract the curated changelog section and create the GitHub release. The curated notes
+# are prepended to GitHub's auto-generated "What's Changed" / "New Contributors" /
+# "Full Changelog" section (--generate-notes). reST double-backticks are collapsed to
+# Markdown single-backticks since the release body is rendered as Markdown.
 github-release:
 	@echo "Extracting changelog for v$(VERSION)..."
-	@awk '/^$(VERSION) /{found=1; next} found && /^\++$$/{next} found && /^[0-9]+\.[0-9]+\.[0-9]+ /{exit} found' HISTORY.rst > /tmp/ia-release-notes-$(VERSION).md
+	@awk '/^$(VERSION) /{found=1; next} found && /^\++$$/{next} found && /^[0-9]+\.[0-9]+\.[0-9]+ /{exit} found' HISTORY.rst \
+		| sed 's/``/`/g' > /tmp/ia-release-notes-$(VERSION).md
+	@test -s /tmp/ia-release-notes-$(VERSION).md || \
+		{ echo "Error: extracted release notes are empty -- check the '$(VERSION)' heading in HISTORY.rst"; exit 1; }
 	gh release create v$(VERSION) \
 		--title "Version $(VERSION)" \
-		--notes-file /tmp/ia-release-notes-$(VERSION).md
+		--notes-file /tmp/ia-release-notes-$(VERSION).md \
+		--generate-notes
 	@rm -f /tmp/ia-release-notes-$(VERSION).md
 	@echo "GitHub release created!"
 
@@ -111,7 +118,7 @@ github-release:
 # it tests, builds the sdist/wheel and pex binary, tags and pushes the tag (never
 # master), uploads to PyPI and the pex to the archive.org item, and creates the
 # GitHub release.
-publish: check-version check-release test build binary test-binary tag push-tag upload-pypi publish-binary-upload github-release
+publish: check-version check-release test build check-dist binary test-binary tag push-tag upload-pypi publish-binary-upload github-release
 	@echo "\n\033[92mRelease v$(VERSION) published to PyPI, archive.org, and GitHub!\033[0m"
 
 # Binary-only release (for publishing binary after PyPI release)

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,6 @@ install_requires =
     requests>=2.25.0,<3.0.0
     tqdm>=4.0.0
     urllib3>=1.26.0
-    importlib-metadata>=3.6.0 ;python_version <= "3.10"
 python_requires = >=3.9
 include_package_data = True
 zip_safe = False
@@ -48,8 +47,8 @@ dev =
     mypy
     pre-commit
     pytest
-    safety
     setuptools
+    twine
 docs =
     alabaster==0.7.12
     docutils<0.18

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -103,14 +103,6 @@ def nasa_mocker():
 
 
 @pytest.fixture
-def nasa_item():
-    session = get_session()
-    with IaRequestsMock() as mocker:
-        mocker.add_metadata_mock('nasa')
-        yield session.get_item('nasa')
-
-
-@pytest.fixture
 def session():
     return get_session(config={'s3': {'access': 'access', 'secret': 'secret'}})
 
@@ -120,7 +112,6 @@ def nasa_metadata():
     return json.loads(load_test_data_file('metadata/nasa.json'))
 
 
-# TODO: Why is this function defined twice in this file?  See issue #505
-@pytest.fixture  # type: ignore
-def nasa_item(nasa_mocker):  # noqa: F811
+@pytest.fixture
+def nasa_item(nasa_mocker):
     return get_item('nasa')


### PR DESCRIPTION
First of a planned series of toolchain-modernization PRs (full audit + roadmap
discussed with maintainer). This is the **low-risk "quick wins" batch** — fixes
accumulated drift in contributor docs, dead tooling, and the release pipeline,
**with no change to library behavior**.

### Contributor onboarding (was actively broken)
- `CONTRIBUTING.rst` "Running Tests" no longer instructs the abandoned
  `pytest-pep8` / `py.test --pep8` (that plugin won't install against the pinned
  pytest 8.4.2). Now: `pip install -e '.[test]'` → `ruff check && pytest`. The PEP8
  bullet points at ruff/`pyproject.toml` instead of the removed `setup.cfg` config.
- `Makefile` `init` installed the same broken set; now `pip install -e '.[all]'`.
  The dead `pep8-test` target is removed.
- `AGENTS.md`/`CLAUDE.md`: dev install now `.[all]`; the "Line length: 90" claim is
  corrected to the actual **102** (the move to 88 lands with the formatter PR).

### Dead dependencies / dead CI gate
- Removed `importlib-metadata` — **nothing in the package imports it** (confirmed).
- Removed `safety` (dev extra) and the `safety check || true` CI step — it could
  never fail (`|| true`) and used safety's deprecated subcommand.
- Added `twine` to the dev extra (the release process already depends on it).

### Release-notes pipeline
- `github-release`: guards the awk extraction with `test -s` (an empty/malformed
  `HISTORY.rst` heading can no longer publish empty notes), collapses reST
  double-backticks → Markdown, and adds `--generate-notes` so GitHub's
  "What's Changed" / "New Contributors" / "Full Changelog" is appended after the
  curated notes.
- Added `.github/release.yml` (categories + bot-author excludes).
- Added a `check-dist` target (`twine check dist/*`) to the publish chain.

### Misc
- `tests/conftest.py`: removed the duplicate `nasa_item` fixture — the second def
  shadowed the first, making it dead code (#505).
- Removed duplicate `plans/` + `.worktrees/` from `.gitignore`.
- Updated the ruff pre-commit URL `charliermarsh` → `astral-sh`.

### Verification
- `ruff check` clean; `pytest` on the `nasa_item`-dependent suites (57 tests) green.
- pre-commit (mypy, setup-cfg-fmt, ruff, black-diff, codespell) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
