### PR TITLE
Unify and modernize the responses test-mock pin (0.26.1)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -56,7 +56,7 @@ docs =
     sphinx-autodoc-typehints==1.18.1
 test =
     pytest==8.4.2
-    responses==0.20.0
+    responses==0.26.1
     ruff==0.14.1
 types =
     tqdm-stubs>=0.2.0

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,3 @@
 pytest==8.4.2
-responses==0.23.1
+responses==0.26.1
 ruff==0.14.1


### PR DESCRIPTION
PR 2 of the toolchain-modernization series.

`responses` was pinned to **two incompatible versions** across test-dependency
sources, and CI installed both in the same job:

| source | was | now |
|---|---|---|
| `setup.cfg` `[test]` | `0.20.0` | `0.26.1` |
| `tests/requirements.txt` | `0.23.1` | `0.26.1` |

`lint_python` installs `.[all]` **and** `-r tests/requirements.txt`, so whichever
pip resolved last silently won — CI and local `pip install -e '.[test]'` could run
against different mock-library versions.

Both are now pinned to the current release **0.26.1**, verified:

- Full mocked suite green on 0.26.1: **288 passed, 37 network-skipped**, no API
  changes needed (`IaRequestsMock` uses only stable public API: `RequestsMock`,
  `.add()`, `responses.GET`).

`responses` is still declared in both files (the editable-install path vs. the
tox/CI path) but now at the same version; collapsing to a single source comes with
the later dependency-groups migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
