### PR TITLE
Update .git-blame-ignore-revs for the rebase-merged reformat SHA

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -2,4 +2,4 @@
 # Locally: git config blame.ignoreRevsFile .git-blame-ignore-revs
 
 # Reformat the codebase with ruff format (black -> ruff format, line length 88)
-e93f236a86e98ae632f612569caa476d326ed02a
+fdb603d0fe7512516b60601149427a026fc7b92c


### PR DESCRIPTION
Rebase-and-merge of #783 rewrote the commit SHAs, so the blame-ignore entry pointed at the pre-merge branch SHA (`e93f236`), which doesn't exist on master. This points it at the reformat commit as it actually landed (`fdb603d`), restoring blame-skipping for the mechanical reformat.

Verified locally: `git blame --ignore-revs-file` attributes reformatted lines to their pre-reformat authors with the new SHA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)