### PR TITLE
Drop Python 3.9 support (floor: Python 3.10)

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -7,7 +7,7 @@ jobs:
       fail-fast: false
       max-parallel: 1  # Avoid timeout errors
       matrix:
-        python: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14', 'pypy-3.11']
+        python: ['3.10', '3.11', '3.12', '3.13', '3.14', 'pypy-3.11']
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-python@v6

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,6 +46,6 @@ repos:
           - types-urllib3
 
   - repo: https://github.com/asottile/setup-cfg-fmt
-    rev: v2.7.0  # Use v2.7.0 until dropping Python 3.9 support
+    rev: v3.2.0
     hooks:
       - id: setup-cfg-fmt

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,7 @@ pytest tests/test_api.py
 # Run a specific test
 pytest tests/test_api.py::test_get_item
 
-# Multi-version testing (requires Python 3.9-3.14 installed)
+# Multi-version testing (requires Python 3.10-3.14 installed)
 tox
 
 # Lint only
@@ -80,7 +80,7 @@ Convenience functions that wrap the core classes: `get_item()`, `search_items()`
 - PRs require tests and must pass ruff linting
 - New features must include documentation updates (see `docs/source/`)
 - Avoid introducing new dependencies
-- Support Python 3.9+
+- Support Python 3.10+
 
 ## Git Workflow
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -40,7 +40,7 @@ Troubleshooting ``pipx`` Installation
 
     pipx ensurepath
 
-- **Python version issues**: Ensure you are using Python 3.9 or later.
+- **Python version issues**: Ensure you are using Python 3.10 or later.
 
 For more details, refer to the `pipx documentation <https://pipx.pypa.io/stable/>`_.
 

--- a/internetarchive/account.py
+++ b/internetarchive/account.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import ClassVar, Dict, List, Optional
+from typing import ClassVar
 
 import requests
 
@@ -45,15 +45,15 @@ class Account:
     canonical_email: str
     itemname: str
     screenname: str
-    notifications: List[str]
+    notifications: list[str]
     has_disability_access: bool
     lastlogin: str
     createdate: str
     session: ArchiveSession = field(default_factory=get_session)
 
     API_BASE_URL: str = '/services/xauthn/'
-    API_INFO_PARAMS: ClassVar[Dict[str, str]] = {'op': 'info'}
-    API_LOCK_UNLOCK_PARAMS: ClassVar[Dict[str, str]] = {'op': 'lock_unlock'}
+    API_INFO_PARAMS: ClassVar[dict[str, str]] = {'op': 'info'}
+    API_LOCK_UNLOCK_PARAMS: ClassVar[dict[str, str]] = {'op': 'lock_unlock'}
 
     def _get_api_base_url(self) -> str:
         """Dynamically construct the API base URL using the session's host."""
@@ -62,9 +62,9 @@ class Account:
     def _post_api_request(
         self,
         endpoint: str,
-        params: Dict[str, str],
-        data: Dict[str, str],
-        session: Optional[ArchiveSession] = None,
+        params: dict[str, str],
+        data: dict[str, str],
+        session: ArchiveSession | None = None,
     ) -> requests.Response:
         """Make a POST request to the Account API.
 
@@ -86,7 +86,7 @@ class Account:
         cls,
         identifier_type: str,
         identifier: str,
-        session: Optional[ArchiveSession] = None,
+        session: ArchiveSession | None = None,
     ) -> "Account":
         """Create an Account by looking up an identifier.
 
@@ -105,8 +105,8 @@ class Account:
         cls,
         identifier_type: str,
         identifier: str,
-        session: Optional[ArchiveSession] = None,
-    ) -> Dict:
+        session: ArchiveSession | None = None,
+    ) -> dict:
         """Fetch account data from the API using an identifier.
 
         :param identifier_type: The type of identifier (e.g., ``'email'``, ``'screenname'``).
@@ -135,7 +135,7 @@ class Account:
 
     @classmethod
     def from_json(
-        cls, json_data: Dict, session: Optional[ArchiveSession] = None
+        cls, json_data: dict, session: ArchiveSession | None = None
     ) -> "Account":
         """Create an Account from JSON data.
 
@@ -186,7 +186,7 @@ class Account:
         )
 
     def lock(
-        self, comment: Optional[str] = None, session: Optional[ArchiveSession] = None
+        self, comment: str | None = None, session: ArchiveSession | None = None
     ) -> requests.Response:
         """Lock the account.
 
@@ -205,7 +205,7 @@ class Account:
         )
 
     def unlock(
-        self, comment: Optional[str] = None, session: Optional[ArchiveSession] = None
+        self, comment: str | None = None, session: ArchiveSession | None = None
     ) -> requests.Response:
         """Unlock the account.
 
@@ -223,7 +223,7 @@ class Account:
             session=session,
         )
 
-    def to_dict(self) -> Dict:
+    def to_dict(self) -> dict:
         """Convert the Account instance to a dictionary.
 
         :returns: A dictionary representation of the Account instance.

--- a/internetarchive/api.py
+++ b/internetarchive/api.py
@@ -28,8 +28,8 @@ This module implements the Internetarchive API.
 
 from __future__ import annotations
 
+from collections.abc import Iterable, Mapping, MutableMapping
 from getpass import getpass
-from typing import Iterable, Mapping, MutableMapping
 
 import requests
 from urllib3 import Retry

--- a/internetarchive/catalog.py
+++ b/internetarchive/catalog.py
@@ -29,9 +29,9 @@ This module contains objects for interacting with the Archive.org catalog.
 from __future__ import annotations
 
 import time
+from collections.abc import Iterable, Iterator, Mapping, MutableMapping
 from datetime import datetime
 from logging import getLogger
-from typing import Iterable, Iterator, Mapping, MutableMapping
 
 import requests
 from requests import Response

--- a/internetarchive/cli/ia_metadata.py
+++ b/internetarchive/cli/ia_metadata.py
@@ -25,8 +25,8 @@ import argparse
 import csv
 import sys
 from collections import defaultdict
+from collections.abc import Mapping
 from copy import copy
-from typing import Mapping
 
 from requests import Request, Response
 

--- a/internetarchive/config.py
+++ b/internetarchive/config.py
@@ -28,9 +28,9 @@ from __future__ import annotations
 
 import os
 from collections import defaultdict
+from collections.abc import Mapping
 from configparser import RawConfigParser
 from time import sleep
-from typing import DefaultDict, Dict, Mapping
 
 import requests
 
@@ -223,9 +223,7 @@ def get_config(config=None, config_file=None) -> dict:
     _config = config or {}
     config_file, _is_xdg, config_parser = parse_config_file(config_file)
 
-    # TODO: Use typing.TypedDict when we drop Python 3.8 support
-    # to get rid of noqa: UP006
-    config_dict: DefaultDict[str, Dict[str, str]] = defaultdict(dict)  # noqa: UP006
+    config_dict: defaultdict[str, dict[str, str]] = defaultdict(dict)
 
     # Read from config file if it exists
     if os.path.isfile(config_file):

--- a/internetarchive/exceptions.py
+++ b/internetarchive/exceptions.py
@@ -24,8 +24,6 @@ internetarchive.exceptions
 :license: AGPL 3, see LICENSE for more details.
 """
 
-from typing import Dict, Optional
-
 
 class AuthenticationError(Exception):
     """Authentication Failed"""
@@ -52,7 +50,7 @@ class InvalidChecksumError(Exception):
 class AccountAPIError(Exception):
     """Base exception for Account API-related errors."""
 
-    def __init__(self, message: str, error_data: Optional[Dict] = None):
+    def __init__(self, message: str, error_data: dict | None = None):
         super().__init__(message)
         self.error_data = error_data
 

--- a/internetarchive/item.py
+++ b/internetarchive/item.py
@@ -31,13 +31,14 @@ import math
 import os
 import socket
 import sys
+from collections.abc import Mapping, MutableMapping
 from copy import deepcopy
 from datetime import datetime
 from fnmatch import fnmatch
 from functools import total_ordering
 from logging import getLogger
 from time import sleep
-from typing import Mapping, MutableMapping, Optional
+from typing import Optional
 from urllib.parse import quote, urlparse
 from xml.parsers.expat import ExpatError
 

--- a/internetarchive/session.py
+++ b/internetarchive/session.py
@@ -37,7 +37,7 @@ import socket
 import sys
 import threading
 import warnings
-from typing import Iterable, Iterator, Mapping, MutableMapping
+from collections.abc import Iterable, Iterator, Mapping, MutableMapping
 from urllib.parse import unquote, urlparse
 
 import requests

--- a/internetarchive/utils.py
+++ b/internetarchive/utils.py
@@ -34,8 +34,7 @@ import platform
 import re
 import sys
 import warnings
-from collections.abc import Mapping
-from typing import Iterable
+from collections.abc import Iterable, Mapping
 from xml.dom.minidom import parseString
 
 # Make preferred JSON package available via `from internetarchive.utils import json`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.ruff]
 line-length = 88
-target-version = "py37"
+target-version = "py310"
 
 [tool.ruff.format]
 # Preserve the project's historical style (black ran with skip-string-normalization):

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,7 +12,6 @@ license_files = LICENSE
 classifiers =
     Development Status :: 5 - Production/Stable
     Intended Audience :: Developers
-    License :: OSI Approved :: GNU Affero General Public License v3
     Natural Language :: English
     Programming Language :: Python
     Programming Language :: Python :: 3
@@ -29,7 +28,7 @@ install_requires =
     requests>=2.25.0,<3.0.0
     tqdm>=4.0.0
     urllib3>=1.26.0
-python_requires = >=3.9
+python_requires = >=3.10
 include_package_data = True
 zip_safe = False
 
@@ -75,7 +74,7 @@ ignore-words-list = alers
 
 [mypy]
 exclude = ^\.git/|^__pycache__/|^docs/source/conf.py$|^old/|^build/|^dist/|\.tox
-python_version = 3.9
+python_version = 3.10
 pretty = True
 scripts_are_modules = True
 show_error_codes = True

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -123,8 +123,9 @@ def test_is_valid_metadata_key():
 
 
 def test_is_windows():
-    with patch('platform.system', return_value='Windows'), patch(
-        'sys.platform', 'win32'
+    with (
+        patch('platform.system', return_value='Windows'),
+        patch('sys.platform', 'win32'),
     ):
         assert internetarchive.utils.is_windows() is True
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{39,310,311,312,313,314},pypy{311}
+envlist = py{310,311,312,313,314},pypy{311}
 
 [testenv]
 deps = -r tests/requirements.txt


### PR DESCRIPTION
## Summary

Python 3.9 reached end-of-life on **2025-10-31**. This PR raises the supported floor to Python 3.10, in line with supporting all still-maintained CPython versions (3.10–3.14). Existing 3.9 users are unaffected: pip's `Requires-Python` handling serves them the last compatible release (5.10.1); they simply stop receiving new versions.

## Changes

- **setup.cfg**: `python_requires = >=3.10`; mypy `python_version = 3.10`
- **tox.ini / tox.yml**: remove the `py39` leg from the test matrix (now 3.10–3.14 + PyPy 3.11)
- **pyproject.toml**: ruff `target-version` `py37` → `py310`
- **pre-commit**: unpin `setup-cfg-fmt` (v2.7.0 was held back solely for 3.9) → v3.2.0. The new hook drops the deprecated `License :: OSI Approved` trove classifier in favor of the `license` field — full SPDX cleanup lands with the packaging migration PR.
- **Code modernization** surfaced by the new py310 lint target (all pyupgrade, behavior-identical): PEP 604 optionals (`X | None`), PEP 585 builtin generics (`dict[...]`), `collections.abc` imports, removal of now-unused `typing` imports, and the `UP006` noqa workaround in `config.py`.
- **tests/test_utils.py**: ruff format now emits 3.10 parenthesized context managers.
- **Docs**: AGENTS.md and installation.rst 3.9 references → 3.10.

## Verification

- `ruff check && ruff format --check && pytest`: clean, 348 passed / 37 skipped
- `pre-commit run --all-files`: all hooks pass (including the new setup-cfg-fmt)

Part of the toolchain modernization series (after #781, #782, #783, #784).

🤖 Generated with [Claude Code](https://claude.com/claude-code)