### PR TITLE
Use uv in CI workflows (uv adoption, Phase 1)

### DIFF
--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -8,7 +8,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: 3.x
-      - uses: astral-sh/setup-uv@v8
+      - uses: astral-sh/setup-uv@v8.2.0
         with:
           enable-cache: true
       - run: uv pip install --system .[all]

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -7,11 +7,12 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-python@v6
         with:
-          cache: pip
           python-version: 3.x
-      - run: pip install --upgrade pip setuptools wheel
-      - run: pip install .[all]
+      - uses: astral-sh/setup-uv@v8
+        with:
+          enable-cache: true
+      - run: uv pip install --system .[all]
       - run: ruff format --check --diff .  # See pyproject.toml for configuration
       - run: ruff check --output-format=github  # See pyproject.toml for configuration
-      - run: pip install -r pex-requirements.txt -r tests/requirements.txt
+      - run: uv pip install --system -r pex-requirements.txt -r tests/requirements.txt
       - run: mypy .  # See setup.cfg for configuration

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -13,8 +13,10 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: 3.x
-          cache: pip
-      - run: pip install pre-commit
+      - uses: astral-sh/setup-uv@v8
+        with:
+          enable-cache: true
+      - run: uv pip install --system pre-commit
       - run: pre-commit --version
       - run: pre-commit install
       - run: pre-commit run --all-files

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: 3.x
-      - uses: astral-sh/setup-uv@v8
+      - uses: astral-sh/setup-uv@v8.2.0
         with:
           enable-cache: true
       - run: uv pip install --system pre-commit

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python }}
-      - uses: astral-sh/setup-uv@v8
+      - uses: astral-sh/setup-uv@v8.2.0
         with:
           enable-cache: true
       # Install tox into the matrix interpreter so `tox -e py` targets it;

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -13,6 +13,10 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python }}
-          cache: pip
-      - run: pip install tox
+      - uses: astral-sh/setup-uv@v8
+        with:
+          enable-cache: true
+      # Install tox into the matrix interpreter so `tox -e py` targets it;
+      # tox-uv makes tox build its test envs with uv.
+      - run: uv pip install --system tox tox-uv
       - run: tox -e py


### PR DESCRIPTION
## Summary

First phase of uv adoption, per the toolchain modernization plan: **CI-only** — no packaging metadata or local-workflow changes. Phase 2 (PEP 735 dependency groups + committed `uv.lock`) lands later with the pyproject packaging migration.

## Changes

- **lint_python / pre-commit / tox workflows**: add `astral-sh/setup-uv@v8` with `enable-cache: true` (replacing the pip cache) and install dependencies with `uv pip install --system`.
- **tox.yml**: install `tox-uv` alongside tox so test envs are built with uv instead of virtualenv+pip. tox is installed into the matrix interpreter — not via `uv tool install` — so `tox -e py` still targets the matrix Python.
- **lint_python.yml**: drop the `pip install --upgrade pip setuptools wheel` bootstrap; unnecessary with uv.
- **test_install.yml deliberately untouched**: its purpose is verifying `pip install .` under old setuptools versions.

## Verification

- `uv pip install` of the package into a clean venv succeeds (legacy setup.cfg build path) — `ia --version` works.
- `tox -e py` with tox-uv locally: env setup ~3s, ruff + full suite green (348 passed / 37 skipped).
- Workflow YAML parses; the real proof is this PR's own CI runs, which now exercise the new steps.

Part of the toolchain modernization series (after #781–#785).

🤖 Generated with [Claude Code](https://claude.com/claude-code)