### PR TITLE
Add tag-triggered release workflow with PyPI Trusted Publishing (OIDC)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,129 @@
+# Tag-triggered release: push a v* tag (e.g. via `make tag push-tag`) and this
+# workflow tests, builds the sdist/wheel and pex, publishes to PyPI via Trusted
+# Publishing (OIDC — no stored token), and creates the GitHub release with the
+# curated HISTORY.rst notes and the pex attached.
+#
+# Prerequisites (one-time, repo/PyPI settings):
+#   - PyPI trusted publisher: owner jjjake, repo internetarchive,
+#     workflow release.yml, environment pypi.
+#   - GitHub environment `pypi` (optionally with a required reviewer).
+#
+# The pex upload to the archive.org `ia-pex` item stays manual (`make
+# publish-binary`) — it needs IA credentials we don't keep in CI.
+# `make publish` remains as a documented laptop fallback.
+name: release
+on:
+  push:
+    tags: ['v*']
+permissions:
+  contents: read
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
+        with:
+          python-version: 3.x
+      - uses: astral-sh/setup-uv@v8.2.0
+        with:
+          enable-cache: true
+      - run: uv pip install --system .[test]
+      - run: pytest -m "not network"
+
+  build:
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
+        with:
+          python-version: 3.x
+      - uses: astral-sh/setup-uv@v8.2.0
+        with:
+          enable-cache: true
+      - name: Verify tag matches package version
+        run: |
+          PKG_VERSION=$(python -c "import re; print(re.search(r\"__version__ = '(.*)'\", open('internetarchive/__version__.py').read()).group(1))")
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          if [ "$PKG_VERSION" != "$TAG_VERSION" ]; then
+            echo "Tag $GITHUB_REF_NAME does not match __version__ $PKG_VERSION" >&2
+            exit 1
+          fi
+          case "$PKG_VERSION" in
+            *dev*) echo "Refusing to release a dev version: $PKG_VERSION" >&2; exit 1 ;;
+          esac
+      - run: uv pip install --system build twine
+      - run: python -m build
+      - run: twine check dist/*
+      - uses: actions/upload-artifact@v7
+        with:
+          name: dist
+          path: dist/
+
+  pex:
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
+        with:
+          python-version: 3.x
+      - uses: astral-sh/setup-uv@v8.2.0
+        with:
+          enable-cache: true
+      - run: uv pip install --system pex
+      - run: make test-binary  # builds the pex (via `binary`) and smoke-tests it
+      - name: Generate sha256 checksum
+        run: sha256sum ia-*.pex > ia-pex.sha256
+      - uses: actions/upload-artifact@v7
+        with:
+          name: pex
+          path: |
+            ia-*.pex
+            ia-pex.sha256
+
+  publish-pypi:
+    runs-on: ubuntu-latest
+    needs: [build, pex]
+    environment:
+      name: pypi
+      url: https://pypi.org/project/internetarchive/
+    permissions:
+      id-token: write  # required for PyPI Trusted Publishing (OIDC)
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          name: dist
+          path: dist/
+      - uses: pypa/gh-action-pypi-publish@release/v1
+
+  github-release:
+    runs-on: ubuntu-latest
+    needs: publish-pypi
+    permissions:
+      contents: write  # create the release and upload assets
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/download-artifact@v8
+        with:
+          name: pex
+      - name: Extract curated notes from HISTORY.rst
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          awk -v ver="$VERSION" '$0 ~ "^"ver" "{found=1; next} found && /^\++$/{next} found && /^[0-9]+\.[0-9]+\.[0-9]+ /{exit} found' HISTORY.rst \
+            | sed 's/``/`/g' > release-notes.md
+          test -s release-notes.md || {
+            echo "Error: extracted release notes are empty -- check the '$VERSION' heading in HISTORY.rst" >&2
+            exit 1
+          }
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "$GITHUB_REF_NAME" \
+            --repo "$GITHUB_REPOSITORY" \
+            --title "Version ${GITHUB_REF_NAME#v}" \
+            --notes-file release-notes.md \
+            --generate-notes \
+            ia-*.pex ia-pex.sha256

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,10 +98,13 @@ When merging new features to master, increment the dev number if needed (e.g., `
 
 ## Releasing
 
-`master` is branch-protected, so a release is two steps: (1) bump the version via a
-PR, then (2) run `make publish` — it tests, builds the sdist/wheel and pex binary,
-pushes the **tag** (never `master`), uploads to PyPI and the pex to archive.org, and
-creates the GitHub release.
+`master` is branch-protected, so a release is three steps: (1) bump the version via a
+PR, (2) push the release tag (`make check-version check-release tag push-tag`) — the
+tag-triggered `release` workflow tests, builds the sdist/wheel and pex, publishes to
+PyPI via Trusted Publishing (OIDC), and creates the GitHub release with the pex
+attached — then (3) `make publish-binary` to upload the pex to the archive.org
+`ia-pex` item (CI has no IA credentials). `make publish` remains a laptop fallback
+when the workflow is unavailable.
 
 Full steps are in the **Releasing** section of `CONTRIBUTING.rst`.
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -67,15 +67,23 @@ Even easier is simply creating a pull request. `GitHub Actions <https://docs.git
 Releasing
 ---------
 
-``master`` is branch-protected (pull requests and required status checks; no direct pushes), so a release is two steps: land the version bump through a pull request, then run ``make publish``.
+``master`` is branch-protected (pull requests and required status checks; no direct pushes), so a release is three steps: land the version bump through a pull request, push the release tag, and upload the ``pex`` binary to archive.org.
 
 #. **Bump the version (via a PR).** On a branch, run ``make prepare-release RELEASE=X.Y.Z`` -- this sets ``internetarchive/__version__.py`` (and the ``HISTORY.rst`` date when the heading is ``X.Y.Z (?)``). Open a pull request with those changes and merge it once CI passes.
 
-#. **Publish.** Update your local ``master`` and run ``make publish``:
+#. **Tag.** Update your local ``master`` and push the release tag:
 
    .. code:: bash
 
        $ git checkout master && git pull
-       $ make publish
+       $ make check-version check-release tag push-tag
 
-   ``make publish`` runs the tests; builds the sdist, wheel, and ``pex`` binary; tags the release and pushes the **tag only** (never ``master``, which is protected); uploads to PyPI; uploads the ``pex`` binary to the ``ia-pex`` archive.org item; and creates the GitHub release. Use ``make publish-binary`` to re-upload just the binary if that step ever needs redoing.
+   Pushing the ``vX.Y.Z`` tag triggers the ``release`` GitHub Actions workflow, which runs the tests, builds and validates the sdist/wheel and ``pex`` binary, publishes to PyPI via `Trusted Publishing <https://docs.pypi.org/trusted-publishers/>`_ (OIDC -- no PyPI token involved), and creates the GitHub release with the curated ``HISTORY.rst`` notes and the ``pex`` (plus its sha256) attached.
+
+#. **Upload the binary to archive.org.** CI has no archive.org credentials, so upload the ``pex`` to the `ia-pex item <https://archive.org/details/ia-pex>`_ from your machine:
+
+   .. code:: bash
+
+       $ make publish-binary
+
+**Fallback:** if the release workflow is unavailable, ``make publish`` still performs the entire release from your machine -- tests, builds, tag push, PyPI upload (requires a PyPI API token), archive.org upload, and the GitHub release. Don't run it after CI has already published; the PyPI upload and GitHub release steps will fail as duplicates.

--- a/Makefile
+++ b/Makefile
@@ -48,8 +48,11 @@ endif
 	@if echo "$(RELEASE)" | grep -q 'dev'; then \
 		echo "Error: RELEASE should not contain 'dev'"; exit 1; \
 	fi
-	sed -i '' "s/__version__ = '.*'/__version__ = '$(RELEASE)'/" internetarchive/__version__.py
-	sed -i '' "s/^$(RELEASE) (?)$$/$(RELEASE) ($$(date +%Y-%m-%d))/" HISTORY.rst
+	@python3 -c "import re, pathlib, datetime; \
+		v = pathlib.Path('internetarchive/__version__.py'); \
+		v.write_text(re.sub(r\"__version__ = '.*'\", \"__version__ = '$(RELEASE)'\", v.read_text())); \
+		h = pathlib.Path('HISTORY.rst'); \
+		h.write_text(h.read_text().replace('$(RELEASE) (?)', '$(RELEASE) (' + datetime.date.today().isoformat() + ')', 1))"
 	@echo "Updated to version $(RELEASE) with date $$(date +%Y-%m-%d)"
 	@echo "Review changes and commit when ready"
 
@@ -63,6 +66,10 @@ check-release:
 	fi
 	@if git rev-parse v$(VERSION) >/dev/null 2>&1; then \
 		echo "Error: Tag v$(VERSION) already exists"; exit 1; \
+	fi
+	@git fetch origin master
+	@if [ "$$(git rev-parse HEAD)" != "$$(git rev-parse origin/master)" ]; then \
+		echo "Error: HEAD is not up to date with origin/master"; exit 1; \
 	fi
 	@echo "Release checks passed!"
 


### PR DESCRIPTION
## Summary

Moves releasing from a laptop-driven `make publish` (long-lived PyPI token) to a tag-triggered GitHub Actions workflow using **PyPI Trusted Publishing** — no stored credentials. The pex binary is built and validated in CI for the first time.

## New release flow

1. Version-bump PR (`make prepare-release`, unchanged)
2. `git checkout master && git pull && make check-version check-release tag push-tag`
3. The `v*` tag triggers **`release.yml`**: test → build sdist/wheel → build+smoke-test pex → publish to PyPI (OIDC, gated by the `pypi` environment) → GitHub release with curated HISTORY.rst notes, `--generate-notes`, and the pex + sha256 attached
4. `make publish-binary` uploads the pex to the archive.org `ia-pex` item (stays manual — CI holds no IA credentials)

`make publish` is retained as the documented laptop fallback.

## Guards

- Tag must match `__version__` and must not be a dev version (fails the build job early)
- `twine check` before upload; pex is smoke-tested (`--version`/`--help`) before attach
- Notes extraction keeps the empty-notes guard
- `make check-release` now does `git fetch` and requires `HEAD == origin/master`
- `make prepare-release`: BSD-only `sed -i ''` → portable Python (verified on macOS)

## ⚠️ One-time setup before the first tag-triggered release (@jjjake)

1. **pypi.org** → project `internetarchive` → Manage → Publishing → add GitHub publisher: owner `jjjake`, repo `internetarchive`, workflow `release.yml`, environment `pypi`
2. **GitHub** → Settings → Environments → create `pypi` (recommended: add yourself as required reviewer so a tag push can't publish without approval)
3. After the first successful OIDC release: revoke the old PyPI API token

Merging this PR before that setup is safe — the workflow only runs on tag pushes (and the publish job would simply fail at the OIDC step if setup is missing).

## Verification

- Workflow YAML validated; notes-extraction awk tested against HISTORY.rst (5.10.1 section extracts correctly, reST backticks converted)
- `make prepare-release RELEASE=9.9.9` tested and reverted; `make check-release` guard logic verified
- Pex built and smoke-tested locally via `make test-binary`
- Tags remain annotated (no GPG key configured); signed tags noted as optional future hardening
- Full CI proof requires an actual tag push — first real release will exercise the workflow end-to-end

Part of the toolchain modernization series (after #781–#787).

🤖 Generated with [Claude Code](https://claude.com/claude-code)