### PR TITLE
Isolate config tests from host XDG_CONFIG_HOME and IA_CONFIG_FILE

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -87,8 +87,8 @@ def test_get_config_with_config_file(tmpdir):
 
 
 def test_get_config_no_config_file():
-    os.environ['HOME'] = ''
-    config = internetarchive.config.get_config()
+    with _environ(HOME='', XDG_CONFIG_HOME=None, IA_CONFIG_FILE=None):
+        config = internetarchive.config.get_config()
     assert config == {}
 
 
@@ -104,8 +104,8 @@ def test_get_config_with_config():
         },
     }
 
-    os.environ['HOME'] = ''
-    config = internetarchive.config.get_config(config=test_conf)
+    with _environ(HOME='', XDG_CONFIG_HOME=None, IA_CONFIG_FILE=None):
+        config = internetarchive.config.get_config(config=test_conf)
     assert config['cookies']['logged-in-sig'] == 'test-sig'
     assert config['cookies']['logged-in-user'] == 'test@archive.org'
     assert config['s3']['access'] == 'custom-access'
@@ -113,8 +113,8 @@ def test_get_config_with_config():
 
 
 def test_get_config_home_not_set():
-    os.environ['HOME'] = '/none'
-    config = internetarchive.config.get_config()
+    with _environ(HOME='/none', XDG_CONFIG_HOME=None, IA_CONFIG_FILE=None):
+        config = internetarchive.config.get_config()
     assert isinstance(config, dict)
 
 
@@ -125,8 +125,8 @@ def test_get_config_home_not_set_with_config():
             'secret': 'no-home-secret',
         },
     }
-    os.environ['HOME'] = '/none'
-    config = internetarchive.config.get_config(config=test_conf)
+    with _environ(HOME='/none', XDG_CONFIG_HOME=None, IA_CONFIG_FILE=None):
+        config = internetarchive.config.get_config(config=test_conf)
     assert isinstance(config, dict)
     assert config['s3']['access'] == 'no-home-access'
     assert config['s3']['secret'] == 'no-home-secret'
@@ -169,20 +169,21 @@ def test_get_config_config_and_config_file(tmpdir):
 
 @contextlib.contextmanager
 def _environ(**kwargs):
+    # A value of None means "ensure the variable is unset".
     old_values = {k: os.environ.get(k) for k in kwargs}
     try:
         for k, v in kwargs.items():
             if v is not None:
                 os.environ[k] = v
             else:
-                del os.environ[k]
+                os.environ.pop(k, None)
         yield
     finally:
         for k, v in old_values.items():
             if v is not None:
                 os.environ[k] = v
             else:
-                del os.environ[k]
+                os.environ.pop(k, None)
 
 
 def _test_parse_config_file(
@@ -192,14 +193,18 @@ def _test_parse_config_file(
     home=None,
     xdg_config_home=None,
     config_file_param=None,
+    ia_config_file=None,
 ):
     # expected_result: (config_file_path, is_xdg); config isn't compared.
     # config_file_contents: str
     # config_file_paths: list of filenames to write config_file_contents to
     # home: str, override HOME env var; default: path of the temporary dir
-    # xdg_config_home: str, set XDG_CONFIG_HOME
+    # xdg_config_home: str, set XDG_CONFIG_HOME; unset if None
     # config_file_param: str, filename to pass to parse_config_file
+    # ia_config_file: str, set IA_CONFIG_FILE; unset if None
     # All paths starting with '$TMPTESTDIR/' get evaluated relative to the temp dir.
+    # XDG_CONFIG_HOME and IA_CONFIG_FILE are cleared unless explicitly given, so
+    # the host environment (e.g. GitHub runners set XDG_CONFIG_HOME) can't leak in.
 
     if not config_file_paths:
         config_file_paths = []
@@ -224,9 +229,11 @@ def _test_parse_config_file(
 
         if home is None:
             home = tmp_test_dir
-        env = {'HOME': home}
-        if xdg_config_home is not None:
-            env['XDG_CONFIG_HOME'] = xdg_config_home
+        env = {
+            'HOME': home,
+            'XDG_CONFIG_HOME': xdg_config_home,
+            'IA_CONFIG_FILE': ia_config_file,
+        }
         with _environ(**env):
             config_file_path, is_xdg, _config = (
                 internetarchive.config.parse_config_file(config_file=config_file_param)
@@ -309,18 +316,18 @@ def test_parse_config_file_direct_path_overrides_existing_files():
 
 
 def test_parse_config_file_with_environment_variable():
-    with _environ(IA_CONFIG_FILE='/inexistent.ia.ini'):
-        _test_parse_config_file(
-            expected_result=('/inexistent.ia.ini', False),
-        )
+    _test_parse_config_file(
+        expected_result=('/inexistent.ia.ini', False),
+        ia_config_file='/inexistent.ia.ini',
+    )
 
 
 def test_parse_config_file_with_environment_variable_and_parameter():
-    with _environ(IA_CONFIG_FILE='/inexistent.ia.ini'):
-        _test_parse_config_file(
-            expected_result=('/inexistent.other.ia.ini', False),
-            config_file_param='/inexistent.other.ia.ini',
-        )
+    _test_parse_config_file(
+        expected_result=('/inexistent.other.ia.ini', False),
+        config_file_param='/inexistent.other.ia.ini',
+        ia_config_file='/inexistent.ia.ini',
+    )
 
 
 def _test_write_config_file(
@@ -348,7 +355,7 @@ def _test_write_config_file(
         ]
         if config_file_param:
             config_file_param = os.path.join(temp_home_dir, config_file_param)
-        with _environ(HOME=temp_home_dir):
+        with _environ(HOME=temp_home_dir, XDG_CONFIG_HOME=None, IA_CONFIG_FILE=None):
             # Need to account for the umask in the expected_modes comparisons.
             # The umask can't just be retrieved, so set and then restore previous value.
             umask = os.umask(0)
@@ -451,7 +458,7 @@ def test_write_config_file_custom_path_existing():
 def test_write_config_file_custom_path_not_existing():
     """Ensure that an exception is thrown if the custom path dir doesn't exist"""
     with tempfile.TemporaryDirectory() as temp_home_dir:
-        with _environ(HOME=temp_home_dir):
+        with _environ(HOME=temp_home_dir, XDG_CONFIG_HOME=None, IA_CONFIG_FILE=None):
             config_file = os.path.join(temp_home_dir, 'foo/ia.ini')
             with pytest.raises(IOError):
                 internetarchive.config.write_config_file({}, config_file)


### PR DESCRIPTION
## Summary

Fixes the 6 `tests/test_config.py` failures that blocked the v5.11.0 release run (https://github.com/jjjake/internetarchive/actions/runs/29947882173). **Test-only change; no library code touched.**

## Root cause

The config tests fake `HOME` but never cleared `XDG_CONFIG_HOME`/`IA_CONFIG_FILE`. `parse_config_file()` consults `XDG_CONFIG_HOME` *before* falling back to `~/.config`, so a host env with it set leaks straight past the `HOME` override.

GitHub's Ubuntu runner image sets `XDG_CONFIG_HOME=$HOME/.config` in `/etc/environment` ([configure-environment.sh](https://github.com/actions/runner-images/blob/main/images/ubuntu/scripts/build/configure-environment.sh)) — and always has. It never bit us because no CI path ran pytest bare: `lint_python` runs no tests, and tox strips inherited env vars from its test environments. The release workflow's `test` job was the first bare `pytest` on a runner. (The pipeline behaved correctly: test failed → build/pex/publish/release all skipped, nothing published.)

Reproducible locally: `XDG_CONFIG_HOME=$HOME/.config pytest tests/test_config.py` fails 11 tests before this fix.

## Changes (all in tests/test_config.py)

- `_environ()`: `None` now means "ensure unset", via `os.environ.pop()` (no `KeyError` on absent vars)
- `_test_parse_config_file()` / `_test_write_config_file()`: always control `XDG_CONFIG_HOME` and `IA_CONFIG_FILE` — unset unless the test case provides them; `IA_CONFIG_FILE` becomes a helper param
- The early `get_config` tests no longer assign `os.environ['HOME']` globally (previously leaked `HOME=''`/`'/none'` into all later tests in the session)

## Verification

- `tests/test_config.py`: 27 passed, both with a clean env and with `XDG_CONFIG_HOME`+`IA_CONFIG_FILE` set to real paths
- Full offline suite under hostile env: 335 passed, 37 skipped
- ruff check/format clean

## After merge

The `v5.11.0` tag points at the failed run's commit and must be moved (delete + re-tag on updated master) to re-fire the release workflow. Nothing was published, so this is safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)